### PR TITLE
Refactor priority queue and update Go version

### DIFF
--- a/examples/manual/main.go
+++ b/examples/manual/main.go
@@ -17,14 +17,14 @@ func main() {
 	logger := log.Default()
 
 	// apply middleware in the same order as you want to execute them
-	srv := worker.RegisterMiddleware(tm,
-		// middleware.YourMiddleware,
-		func(next worker.Service) worker.Service {
-			return middleware.NewLoggerMiddleware(next, logger)
-		},
-	)
+        srv := worker.RegisterMiddleware[worker.Service](tm,
+                // middleware.YourMiddleware,
+                func(next worker.Service) worker.Service {
+                        return middleware.NewLoggerMiddleware(next, logger)
+                },
+        )
 
-	task := worker.Task{
+	task := &worker.Task{
 		ID:       uuid.New(),
 		Priority: 1,
 		Execute:  func() (val interface{}, err error) { return "Hello, World from Task!", err },

--- a/examples/middleware/main.go
+++ b/examples/middleware/main.go
@@ -17,7 +17,7 @@ func main() {
 
 	var srv worker.Service = tm
 	// apply middleware in the same order as you want to execute them
-	srv = worker.RegisterMiddleware(tm,
+	srv = worker.RegisterMiddleware[worker.Service](srv,
 		// middleware.YourMiddleware,
 		func(next worker.Service) worker.Service {
 			return middleware.NewLoggerMiddleware(next, middleware.DefaultLogger())
@@ -26,7 +26,7 @@ func main() {
 
 	// defer srv.Stop()
 
-	task := worker.Task{
+	task := &worker.Task{
 		ID:       uuid.New(),
 		Priority: 1,
 		Execute: func() (val interface{}, err error) {
@@ -37,13 +37,13 @@ func main() {
 	}
 
 	// Invalid task, it doesn't have a function
-	task1 := worker.Task{
+	task1 := &worker.Task{
 		ID:       uuid.New(),
 		Priority: 10,
 		// Execute:       func() (val interface{}, err error) { return "Hello, World from Task 1!", err },
 	}
 
-	task2 := worker.Task{
+	task2 := &worker.Task{
 		ID:       uuid.New(),
 		Priority: 5,
 		Execute: func() (val interface{}, err error) {
@@ -53,7 +53,7 @@ func main() {
 		Ctx: context.TODO(),
 	}
 
-	task3 := worker.Task{
+	task3 := &worker.Task{
 		ID:       uuid.New(),
 		Priority: 90,
 		Execute: func() (val interface{}, err error) {
@@ -63,7 +63,7 @@ func main() {
 		},
 	}
 
-	task4 := worker.Task{
+	task4 := &worker.Task{
 		ID:       uuid.New(),
 		Priority: 150,
 		Execute: func() (val interface{}, err error) {

--- a/examples/multi/multi.go
+++ b/examples/multi/multi.go
@@ -22,7 +22,7 @@ func main() {
 			j := i
 			// create a new task
 			id := uuid.New()
-			task := worker.Task{
+			task := &worker.Task{
 				ID:          id,
 				Name:        "Some task",
 				Description: "Here goes the description of the task",
@@ -51,7 +51,7 @@ func main() {
 			j := i
 			// create a new task
 			id := uuid.New()
-			task := worker.Task{
+			task := &worker.Task{
 				ID: id,
 				Execute: func() (val interface{}, err error) {
 					emptyFile, error := os.Create(path.Join("examples", "multi", "res", fmt.Sprintf("2nd__EmptyFile___%v.txt", j)))
@@ -77,7 +77,7 @@ func main() {
 		j := i
 		// create a new task
 		id := uuid.New()
-		task := worker.Task{
+		task := &worker.Task{
 			ID: id,
 			Execute: func() (val interface{}, err error) {
 				emptyFile, error := os.Create(path.Join("examples", "multi", "res", fmt.Sprintf("3nd__EmptyFile___%v.txt", j)))
@@ -102,7 +102,7 @@ func main() {
 		j := i
 		// create a new task
 		id := uuid.New()
-		task := worker.Task{
+		task := &worker.Task{
 			ID: id,
 			Execute: func() (val interface{}, err error) {
 				emptyFile, err := os.Create(path.Join("examples", "wrong-path", "res", fmt.Sprintf("4nd__EmptyFile___%v.txt", j)))

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hyp3rd/go-worker
 
-go 1.20
+go 1.25
 
 require (
 	github.com/google/uuid v1.3.0

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,29 @@
+package worker
+
+import "sync/atomic"
+
+// taskMetrics holds counters for task lifecycle events.
+type taskMetrics struct {
+	scheduled atomic.Int64
+	completed atomic.Int64
+	failed    atomic.Int64
+	cancelled atomic.Int64
+}
+
+// MetricsSnapshot represents a snapshot of task metrics.
+type MetricsSnapshot struct {
+	Scheduled int64
+	Completed int64
+	Failed    int64
+	Cancelled int64
+}
+
+// GetMetrics returns a snapshot of current metrics.
+func (tm *TaskManager) GetMetrics() MetricsSnapshot {
+	return MetricsSnapshot{
+		Scheduled: tm.metrics.scheduled.Load(),
+		Completed: tm.metrics.completed.Load(),
+		Failed:    tm.metrics.failed.Load(),
+		Cancelled: tm.metrics.cancelled.Load(),
+	}
+}

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -41,7 +41,7 @@ func NewLoggerMiddleware(next worker.Service, logger Logger) worker.Service {
 }
 
 // RegisterTask registers a new task to the worker
-func (mw *loggerMiddleware) RegisterTask(ctx context.Context, task worker.Task) error {
+func (mw *loggerMiddleware) RegisterTask(ctx context.Context, task *worker.Task) error {
 	defer func(begin time.Time) {
 		if task.Error.Load() != nil {
 			mw.logger.Printf("error while registering task ID %v - %v", task.ID, task.Error.Load())
@@ -56,7 +56,7 @@ func (mw *loggerMiddleware) RegisterTask(ctx context.Context, task worker.Task) 
 }
 
 // RegisterTasks registers multiple tasks to the worker
-func (mw *loggerMiddleware) RegisterTasks(ctx context.Context, tasks ...worker.Task) {
+func (mw *loggerMiddleware) RegisterTasks(ctx context.Context, tasks ...*worker.Task) {
 	defer func(begin time.Time) {
 		for _, t := range tasks {
 			if t.Error.Load() != nil {
@@ -81,6 +81,11 @@ func (mw *loggerMiddleware) StartWorkers() {
 	}(time.Now())
 
 	mw.next.StartWorkers()
+}
+
+// SetMaxWorkers adjusts the worker pool size
+func (mw *loggerMiddleware) SetMaxWorkers(n int) {
+	mw.next.SetMaxWorkers(n)
 }
 
 // Stop the task manage
@@ -133,7 +138,7 @@ func (mw *loggerMiddleware) GetResults() []worker.Result {
 }
 
 // GetCancelledTasks streams the cancelled tasks channel
-func (mw *loggerMiddleware) GetCancelledTasks() <-chan worker.Task {
+func (mw *loggerMiddleware) GetCancelledTasks() <-chan *worker.Task {
 	return mw.next.GetCancelledTasks()
 }
 
@@ -143,7 +148,7 @@ func (mw *loggerMiddleware) GetTask(id uuid.UUID) (task *worker.Task, err error)
 }
 
 // GetTasks gets all tasks
-func (mw *loggerMiddleware) GetTasks() []worker.Task {
+func (mw *loggerMiddleware) GetTasks() []*worker.Task {
 	return mw.next.GetTasks()
 }
 

--- a/tests/worker_test.go
+++ b/tests/worker_test.go
@@ -18,13 +18,15 @@ func TestTaskManager_NewTaskManager(t *testing.T) {
 
 func TestTaskManager_RegisterTask(t *testing.T) {
 	tm := worker.NewTaskManager(context.TODO(), 4, 10, 5, time.Second*30, time.Second*30, 3)
-	task := worker.Task{
+	task := &worker.Task{
 		ID:       uuid.New(),
 		Execute:  func() (val interface{}, err error) { return nil, err },
 		Priority: 10,
 	}
 
-	tm.RegisterTask(context.TODO(), task)
+	if err := tm.RegisterTask(context.TODO(), task); err != nil {
+		t.Fatalf("RegisterTask returned error: %v", err)
+	}
 
 	tk, err := tm.GetTask(task.ID)
 	if err != nil {
@@ -40,12 +42,14 @@ func TestTaskManager_RegisterTask(t *testing.T) {
 
 func TestTaskManager_Start(t *testing.T) {
 	tm := worker.NewTaskManager(context.TODO(), 4, 10, 5, time.Second*30, time.Second*30, 3)
-	task := worker.Task{
+	task := &worker.Task{
 		ID:       uuid.New(),
 		Execute:  func() (val interface{}, err error) { return "task", err },
 		Priority: 10,
 	}
-	tm.RegisterTask(context.TODO(), task)
+	if err := tm.RegisterTask(context.TODO(), task); err != nil {
+		t.Fatalf("RegisterTask returned error: %v", err)
+	}
 
 	res := <-tm.StreamResults()
 	if res.Task == nil {
@@ -55,12 +59,14 @@ func TestTaskManager_Start(t *testing.T) {
 
 func TestTaskManager_StreamResults(t *testing.T) {
 	tm := worker.NewTaskManager(context.TODO(), 4, 10, 5, time.Second*30, time.Second*30, 3)
-	task := worker.Task{
+	task := &worker.Task{
 		ID:       uuid.New(),
 		Execute:  func() (val interface{}, err error) { return "task", err },
 		Priority: 10,
 	}
-	tm.RegisterTask(context.TODO(), task)
+	if err := tm.RegisterTask(context.TODO(), task); err != nil {
+		t.Fatalf("RegisterTask returned error: %v", err)
+	}
 
 	results := <-tm.StreamResults()
 	if results.Task == nil {
@@ -70,12 +76,14 @@ func TestTaskManager_StreamResults(t *testing.T) {
 
 func TestTaskManager_GetTask(t *testing.T) {
 	tm := worker.NewTaskManager(context.TODO(), 4, 10, 5, time.Second*30, time.Second*30, 3)
-	task := worker.Task{
+	task := &worker.Task{
 		ID:       uuid.New(),
 		Execute:  func() (val interface{}, err error) { return "task", err },
 		Priority: 10,
 	}
-	tm.RegisterTask(context.TODO(), task)
+	if err := tm.RegisterTask(context.TODO(), task); err != nil {
+		t.Fatalf("RegisterTask returned error: %v", err)
+	}
 	tk, err := tm.GetTask(task.ID)
 	if err != nil {
 		t.Fatalf("Task was not found in the registry")
@@ -88,12 +96,14 @@ func TestTaskManager_GetTask(t *testing.T) {
 
 func TestTaskManager_ExecuteTask(t *testing.T) {
 	tm := worker.NewTaskManager(context.TODO(), 4, 10, 5, time.Second*30, time.Second*30, 3)
-	task := worker.Task{
+	task := &worker.Task{
 		ID:       uuid.New(),
 		Execute:  func() (val interface{}, err error) { return "task", err },
 		Priority: 10,
 	}
-	tm.RegisterTask(context.TODO(), task)
+	if err := tm.RegisterTask(context.TODO(), task); err != nil {
+		t.Fatalf("RegisterTask returned error: %v", err)
+	}
 
 	res, err := tm.ExecuteTask(task.ID, time.Second*10)
 	if err != nil {


### PR DESCRIPTION
## Summary
- switch task and cancellation channels to pointer types
- add generic middleware and priority queue with dynamic worker scaling and metrics
- implement context-aware exponential backoff

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689f913e5f7883309b77eb4e4459cd6f