### PR TITLE
chore: modernize workflows to Go 1.25 and add tests

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -36,7 +36,15 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - name: Run tests
+        run: go test ./...
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.25'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -59,6 +64,9 @@ jobs:
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
+
+    - name: Run tests
+      run: go test ./...
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,12 +14,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.19
+        go-version: '1.25'
 
     - name: Build
       run: go build -v ./...

--- a/tests/task_test.go
+++ b/tests/task_test.go
@@ -1,0 +1,51 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	worker "github.com/hyp3rd/go-worker"
+)
+
+func TestTask_IsValid(t *testing.T) {
+	// valid task
+	task := &worker.Task{
+		ID:      uuid.New(),
+		Ctx:     context.Background(),
+		Execute: func() (interface{}, error) { return nil, nil },
+	}
+	if err := task.IsValid(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// invalid id
+	task = &worker.Task{
+		ID:      uuid.Nil,
+		Ctx:     context.Background(),
+		Execute: func() (interface{}, error) { return nil, nil },
+	}
+	if err := task.IsValid(); err != worker.ErrInvalidTaskID {
+		t.Fatalf("expected ErrInvalidTaskID, got %v", err)
+	}
+
+	// nil context
+	task = &worker.Task{
+		ID:      uuid.New(),
+		Ctx:     nil,
+		Execute: func() (interface{}, error) { return nil, nil },
+	}
+	if err := task.IsValid(); err != worker.ErrInvalidTaskContext {
+		t.Fatalf("expected ErrInvalidTaskContext, got %v", err)
+	}
+
+	// nil execute func
+	task = &worker.Task{
+		ID:      uuid.New(),
+		Ctx:     context.Background(),
+		Execute: nil,
+	}
+	if err := task.IsValid(); err != worker.ErrInvalidTaskFunc {
+		t.Fatalf("expected ErrInvalidTaskFunc, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- use Go 1.25 in all CI workflows
- run `go test` in security workflows
- add unit tests for `Task.IsValid`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689fa4fb75148330844fd23203111dde