### PR TITLE
docs: expand README with architecture and community guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Placeholder for upcoming changes.
+
+## [v0.1.0] - 2025-08-16
+
+### Added
+- Initial release of go-worker with prioritized concurrent task execution.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,33 @@ Each `Task` represents a function scheduled by priority.
 - Rate limiting: You can rate limit the tasks schedule by setting a maximum number of jobs per second.
 - Cancellation: You can cancel Tasks before or while they are running.
 
-## API
+## Architecture
+
+```mermaid
+flowchart LR
+    Client[Client code] -->|register tasks| TaskManager
+    TaskManager --> Queue[Priority Queue]
+    Queue -->|dispatch| Worker1[Worker]
+    Queue -->|dispatch| WorkerN[Worker]
+    Worker1 --> Results[Results Channel]
+    WorkerN --> Results
+```
+
+## API Usage Examples
+
+### Quick Start
+
+```go
+tm := worker.NewTaskManager(2, 10, 5, time.Second, time.Second, 3)
+defer tm.Close()
+
+task := worker.Task{ID: uuid.New(), Priority: 1, Fn: func() (any, error) { return "hello", nil }}
+tm.RegisterTask(context.Background(), task)
+
+for res := range tm.GetResults() {
+    fmt.Println(res)
+}
+```
 
 ### Initialization
 
@@ -204,6 +230,26 @@ func main() {
     }
 }
 ```
+
+## Versioning
+
+This project follows [Semantic Versioning](https://semver.org/). Release notes are available in [CHANGELOG.md](CHANGELOG.md).
+
+## Contribution Guidelines
+
+We welcome contributions! Fork the repository, create a feature branch, run the linters and tests, then open a pull request.
+
+### Feature Requests
+
+To propose new ideas, open an issue using the *Feature request* template.
+
+### Newcomer-Friendly Issues
+
+Issues labeled `good first issue` or `help wanted` are ideal starting points for new contributors.
+
+## Release Notes
+
+See [CHANGELOG.md](CHANGELOG.md) for the history of released versions.
 
 ## Conclusion
 


### PR DESCRIPTION
## Summary
- document task processing architecture and provide a quick start API example
- outline contribution process with feature requests and newcomer-friendly issues
- add changelog to formalize versioning and release notes

## Testing
- `pre-commit run --files README.md CHANGELOG.md` *(fails: go: no such tool "covdata")*


------
https://chatgpt.com/codex/tasks/task_e_68a0d0e3eb9883308bf2728213e65221