### PR TITLE
feat: expand gRPC task definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ client := workerpb.NewWorkerServiceClient(conn)
 
 // register a task
 _, _ = client.RegisterTasks(ctx, &workerpb.RegisterTasksRequest{
-    Tasks: []*workerpb.Task{{Name: "demo", Payload: "hello"}},
+    Tasks: []*workerpb.Task{{Name: "demo", Description: "demo task"}},
 })
 
 // cancel by id

--- a/examples/grpc/main.go
+++ b/examples/grpc/main.go
@@ -1,16 +1,17 @@
 package main
 
 import (
-	"context"
-	"log"
-	"net"
-	"time"
+        "context"
+        "log"
+        "net"
+        "time"
 
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+        "google.golang.org/grpc"
+        "google.golang.org/grpc/credentials/insecure"
+        "google.golang.org/protobuf/types/known/durationpb"
 
-	worker "github.com/hyp3rd/go-worker"
-	workerpb "github.com/hyp3rd/go-worker/pkg/worker/v1"
+        worker "github.com/hyp3rd/go-worker"
+        workerpb "github.com/hyp3rd/go-worker/pkg/worker/v1"
 )
 
 func main() {
@@ -56,8 +57,16 @@ func main() {
 	defer cancel()
 
 	_, err = client.RegisterTasks(cctx, &workerpb.RegisterTasksRequest{
-		Tasks: []*workerpb.Task{{Name: "demo", Payload: "hello"}},
-	})
+                Tasks: []*workerpb.Task{
+                        {
+                                Name:        "demo",
+                                Description: "demo task",
+                                Priority:    1,
+                                Retries:     0,
+                                RetryDelay:  durationpb.New(time.Second),
+                        },
+                },
+        })
 	if err != nil {
 		log.Printf("register: %v", err)
 

--- a/grpc.go
+++ b/grpc.go
@@ -1,122 +1,127 @@
 package worker
 
 import (
-	"context"
-	"fmt"
+        "context"
+        "fmt"
 
-	"github.com/google/uuid"
+        "github.com/google/uuid"
 
-	workerpb "github.com/hyp3rd/go-worker/pkg/worker/v1"
+        workerpb "github.com/hyp3rd/go-worker/pkg/worker/v1"
 )
 
 // GRPCServer implements the generated WorkerServiceServer interface.
 type GRPCServer struct {
-	svc Service
+        svc Service
 }
 
 // NewGRPCServer creates a new gRPC server backed by the provided Service.
 func NewGRPCServer(svc Service) *GRPCServer {
-	return &GRPCServer{svc: svc}
+        return &GRPCServer{svc: svc}
 }
 
 // RegisterTasks registers one or more tasks with the underlying service.
 func (s *GRPCServer) RegisterTasks(ctx context.Context, req *workerpb.RegisterTasksRequest) (*workerpb.RegisterTasksResponse, error) {
-	tasks := make([]*Task, 0, len(req.GetTasks()))
+        tasks := make([]*Task, 0, len(req.GetTasks()))
 
-	for _, taskReq := range req.GetTasks() {
-		payload := taskReq.GetPayload()
+        for _, taskReq := range req.GetTasks() {
+                task, err := NewTask(ctx, func(ctx context.Context, args ...any) (any, error) {
+                        return fmt.Sprintf("executed %s", taskReq.GetName()), nil
+                })
+                if err != nil {
+                        return nil, err
+                }
 
-		task, err := NewTask(ctx, func(ctx context.Context, args ...any) (any, error) {
-			return payload, nil
-		})
-		if err != nil {
-			return nil, err
-		}
+                task.Name = taskReq.GetName()
+                task.Description = taskReq.GetDescription()
+                task.Priority = int(taskReq.GetPriority())
+                task.Retries = int(taskReq.GetRetries())
+                if d := taskReq.GetRetryDelay(); d != nil {
+                        task.RetryDelay = d.AsDuration()
+                }
 
-		task.Name = taskReq.GetName()
-		tasks = append(tasks, task)
-	}
+                tasks = append(tasks, task)
+        }
 
-	s.svc.RegisterTasks(ctx, tasks...)
+        s.svc.RegisterTasks(ctx, tasks...)
 
-	ids := make([]string, len(tasks))
-	for i, task := range tasks {
-		ids[i] = task.ID.String()
-	}
+        ids := make([]string, len(tasks))
+        for i, task := range tasks {
+                ids[i] = task.ID.String()
+        }
 
-	return &workerpb.RegisterTasksResponse{Ids: ids}, nil
+        return &workerpb.RegisterTasksResponse{Ids: ids}, nil
 }
 
 // StreamResults streams task results back to the client.
 func (s *GRPCServer) StreamResults(req *workerpb.StreamResultsRequest, stream workerpb.WorkerService_StreamResultsServer) error {
-	results := s.svc.StreamResults()
+        results := s.svc.StreamResults()
 
-	for {
-		select {
-		case <-stream.Context().Done():
-			return fmt.Errorf("stream context: %w", stream.Context().Err())
-		case res, ok := <-results:
-			if !ok {
-				return nil
-			}
+        for {
+                select {
+                case <-stream.Context().Done():
+                        return fmt.Errorf("stream context: %w", stream.Context().Err())
+                case res, ok := <-results:
+                        if !ok {
+                                return nil
+                        }
 
-			out := &workerpb.StreamResultsResponse{Id: res.Task.ID.String()}
+                        out := &workerpb.StreamResultsResponse{Id: res.Task.ID.String()}
 
-			if res.Result != nil {
-				out.Output = fmt.Sprint(res.Result)
-			}
+                        if res.Result != nil {
+                                out.Output = fmt.Sprint(res.Result)
+                        }
 
-			if res.Error != nil {
-				out.Error = res.Error.Error()
-			}
+                        if res.Error != nil {
+                                out.Error = res.Error.Error()
+                        }
 
-			err := stream.Send(out)
-			if err != nil {
-				return fmt.Errorf("stream send: %w", err)
-			}
-		}
-	}
+                        err := stream.Send(out)
+                        if err != nil {
+                                return fmt.Errorf("stream send: %w", err)
+                        }
+                }
+        }
 }
 
 // CancelTask cancels an active task by its ID.
 func (s *GRPCServer) CancelTask(ctx context.Context, req *workerpb.CancelTaskRequest) (*workerpb.CancelTaskResponse, error) {
-	id, err := uuid.Parse(req.GetId())
-	if err != nil {
-		return nil, fmt.Errorf("parse id: %w", err)
-	}
+        id, err := uuid.Parse(req.GetId())
+        if err != nil {
+                return nil, fmt.Errorf("parse id: %w", err)
+        }
 
-	s.svc.CancelTask(id)
+        s.svc.CancelTask(id)
 
-	return &workerpb.CancelTaskResponse{}, nil
+        return &workerpb.CancelTaskResponse{}, nil
 }
 
 // GetTask returns information about a task by its ID.
 func (s *GRPCServer) GetTask(ctx context.Context, req *workerpb.GetTaskRequest) (*workerpb.GetTaskResponse, error) {
-	id, err := uuid.Parse(req.GetId())
-	if err != nil {
-		return nil, fmt.Errorf("parse id: %w", err)
-	}
+        id, err := uuid.Parse(req.GetId())
+        if err != nil {
+                return nil, fmt.Errorf("parse id: %w", err)
+        }
 
-	task, err := s.svc.GetTask(id)
-	if err != nil {
-		return nil, fmt.Errorf("get task: %w", err)
-	}
+        task, err := s.svc.GetTask(id)
+        if err != nil {
+                return nil, fmt.Errorf("get task: %w", err)
+        }
 
-	resp := &workerpb.GetTaskResponse{
-		Id:     task.ID.String(),
-		Name:   task.Name,
-		Status: task.Status.String(),
-	}
+        resp := &workerpb.GetTaskResponse{
+                Id:     task.ID.String(),
+                Name:   task.Name,
+                Status: task.Status.String(),
+        }
 
-	if v := task.Result.Load(); v != nil {
-		resp.Output = fmt.Sprint(v)
-	}
+        if v := task.Result.Load(); v != nil {
+                resp.Output = fmt.Sprint(v)
+        }
 
-	if v := task.Error.Load(); v != nil {
-		resp.Error = fmt.Sprint(v)
-	}
+        if v := task.Error.Load(); v != nil {
+                resp.Error = fmt.Sprint(v)
+        }
 
-	return resp, nil
+        return resp, nil
 }
 
 var _ workerpb.WorkerServiceServer = (*GRPCServer)(nil)

--- a/pkg/worker/v1/worker.pb.go
+++ b/pkg/worker/v1/worker.pb.go
@@ -13,6 +13,7 @@ import (
 
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+        durationpb "google.golang.org/protobuf/types/known/durationpb"
 )
 
 const (
@@ -23,12 +24,16 @@ const (
 )
 
 type Task struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Payload       string                 `protobuf:"bytes,2,opt,name=payload,proto3" json:"payload,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+        state         protoimpl.MessageState `protogen:"open.v1"`
+        Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+        Description   string                 `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
+        Priority      int32                  `protobuf:"varint,3,opt,name=priority,proto3" json:"priority,omitempty"`
+        Retries       int32                  `protobuf:"varint,4,opt,name=retries,proto3" json:"retries,omitempty"`
+        RetryDelay    *durationpb.Duration   `protobuf:"bytes,5,opt,name=retry_delay,json=retryDelay,proto3" json:"retry_delay,omitempty"`
+        unknownFields protoimpl.UnknownFields
+        sizeCache     protoimpl.SizeCache
 }
+
 
 func (x *Task) Reset() {
 	*x = Task{}
@@ -61,17 +66,38 @@ func (*Task) Descriptor() ([]byte, []int) {
 }
 
 func (x *Task) GetName() string {
-	if x != nil {
-		return x.Name
-	}
-	return ""
+        if x != nil {
+                return x.Name
+        }
+        return ""
 }
 
-func (x *Task) GetPayload() string {
-	if x != nil {
-		return x.Payload
-	}
-	return ""
+func (x *Task) GetDescription() string {
+        if x != nil {
+                return x.Description
+        }
+        return ""
+}
+
+func (x *Task) GetPriority() int32 {
+        if x != nil {
+                return x.Priority
+        }
+        return 0
+}
+
+func (x *Task) GetRetries() int32 {
+        if x != nil {
+                return x.Retries
+        }
+        return 0
+}
+
+func (x *Task) GetRetryDelay() *durationpb.Duration {
+        if x != nil {
+                return x.RetryDelay
+        }
+        return nil
 }
 
 type RegisterTasksRequest struct {

--- a/proto/worker/v1/worker.proto
+++ b/proto/worker/v1/worker.proto
@@ -2,11 +2,16 @@ syntax = "proto3";
 
 package worker.v1;
 
+import "google/protobuf/duration.proto";
+
 option go_package = "github.com/hyp3rd/go-worker/pkg/worker/v1;workerpb";
 
 message Task {
   string name = 1;
-  string payload = 2;
+  string description = 2;
+  int32 priority = 3;
+  int32 retries = 4;
+  google.protobuf.Duration retry_delay = 5;
 }
 
 message RegisterTasksRequest {


### PR DESCRIPTION
## Summary
- extend gRPC `Task` message with description, priority, retries, and retry delay
- build server-side tasks from new fields and execute the task function
- update example and docs for revised API

## Testing
- `go test ./...` *(fails: go: No such file or directory)*
- `buf generate` *(fails: buf: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f64110cc8330a2144f8073c9e26b