### PR TITLE
feat(task): add bounded jitter to retry backoff to spread load

### DIFF
--- a/task_retry_jitter_test.go
+++ b/task_retry_jitter_test.go
@@ -1,0 +1,35 @@
+package worker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const retryJitterTestDelay = time.Second
+
+func TestRetryJitterDelayWithinBounds(t *testing.T) {
+	t.Parallel()
+
+	task := &Task{
+		ID:         uuid.MustParse("11111111-2222-3333-4444-555555555555"),
+		RetryDelay: retryJitterTestDelay,
+		Retries:    1,
+	}
+
+	task.initRetryState(retryJitterTestDelay, 1)
+
+	delay, ok := task.nextRetryDelay()
+	if !ok {
+		t.Fatal("expected retry delay to be available")
+	}
+
+	span := retryJitterTestDelay / retryJitterDivisor
+	lower := retryJitterTestDelay - span/2
+	upper := retryJitterTestDelay + span/2
+
+	if delay < lower || delay > upper {
+		t.Fatalf("expected retry delay within [%v, %v], got %v", lower, upper, delay)
+	}
+}


### PR DESCRIPTION
- Apply a deterministic ±10% jitter to computed retry delays to reduce synchronized retries (“thundering herd”).
- Jitter is derived from the task UUID and the current attempt using a simple bit-mix hash.
- Capture the attempt count before decrementing so jitter is based on the correct try.
- Add unit test (task_retry_jitter_test.go) to ensure delays remain within [delay - delay/10, delay + delay/10].