### PR TITLE
feat(hooks): add task lifecycle hooks and integrate into TaskManager/…

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,24 @@ tm.SetRetentionPolicy(worker.RetentionPolicy{
 })
 ```
 
+Task lifecycle hooks can be configured for structured logging or tracing:
+
+```go
+tm.SetHooks(worker.TaskHooks{
+    OnQueued: func(task *worker.Task) {
+        // log enqueue
+    },
+    OnStart: func(task *worker.Task) {
+        // log start
+    },
+    OnFinish: func(task *worker.Task, status worker.TaskStatus, _ any, err error) {
+        // log completion
+        _ = err
+        _ = status
+    },
+})
+```
+
 ### Registering Tasks
 
 Register new tasks by calling the `RegisterTasks()` method of the `TaskManager` struct and passing in a variadic number of tasks.

--- a/hooks.go
+++ b/hooks.go
@@ -1,0 +1,69 @@
+package worker
+
+import (
+	"log/slog"
+	"time"
+)
+
+// TaskHooks defines optional callbacks for task lifecycle events.
+type TaskHooks struct {
+	OnQueued func(task *Task)
+	OnStart  func(task *Task)
+	OnFinish func(task *Task, status TaskStatus, result any, err error)
+	OnRetry  func(task *Task, delay time.Duration, attempt int)
+}
+
+// SetHooks configures callbacks for task lifecycle events.
+func (tm *TaskManager) SetHooks(hooks TaskHooks) {
+	h := hooks
+	tm.hooks.Store(&h)
+}
+
+func (tm *TaskManager) hookQueued(task *Task) {
+	hooks := tm.hooks.Load()
+	if hooks == nil || hooks.OnQueued == nil {
+		return
+	}
+
+	runHook(func() { hooks.OnQueued(task) })
+}
+
+func (tm *TaskManager) hookStart(task *Task) {
+	hooks := tm.hooks.Load()
+	if hooks == nil || hooks.OnStart == nil {
+		return
+	}
+
+	runHook(func() { hooks.OnStart(task) })
+}
+
+func (tm *TaskManager) hookFinish(task *Task, status TaskStatus, result any, err error) {
+	hooks := tm.hooks.Load()
+	if hooks == nil || hooks.OnFinish == nil {
+		return
+	}
+
+	runHook(func() { hooks.OnFinish(task, status, result, err) })
+}
+
+func (tm *TaskManager) hookRetry(task *Task, delay time.Duration, attempt int) {
+	hooks := tm.hooks.Load()
+	if hooks == nil || hooks.OnRetry == nil {
+		return
+	}
+
+	runHook(func() { hooks.OnRetry(task, delay, attempt) })
+}
+
+func runHook(fn func()) {
+	defer func() {
+		err := recover()
+		if err != nil {
+			logger := slog.Default()
+			// Log the panic from the hook to avoid crashing the task manager.
+			logger.Error("task hook panic", "error", err)
+		}
+	}()
+
+	fn()
+}

--- a/interface.go
+++ b/interface.go
@@ -13,6 +13,7 @@ type Service interface {
 	taskOperations
 	metricsOperations
 	retentionOperations
+	hooksOperations
 }
 
 type workerOperations interface {
@@ -57,6 +58,11 @@ type metricsOperations interface {
 type retentionOperations interface {
 	// SetRetentionPolicy configures task registry retention.
 	SetRetentionPolicy(policy RetentionPolicy)
+}
+
+type hooksOperations interface {
+	// SetHooks configures task lifecycle hooks.
+	SetHooks(hooks TaskHooks)
 }
 
 // Middleware describes a generic middleware.

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -179,3 +179,8 @@ func (mw *loggerMiddleware) GetMetrics() worker.MetricsSnapshot {
 func (mw *loggerMiddleware) SetRetentionPolicy(policy worker.RetentionPolicy) {
 	mw.next.SetRetentionPolicy(policy)
 }
+
+// SetHooks configures task lifecycle hooks.
+func (mw *loggerMiddleware) SetHooks(hooks worker.TaskHooks) {
+	mw.next.SetHooks(hooks)
+}

--- a/task.go
+++ b/task.go
@@ -373,15 +373,15 @@ func (task *Task) isQueued() bool {
 	return task.status == Queued
 }
 
-func (task *Task) nextRetryDelay() (time.Duration, bool) {
+func (task *Task) nextRetryDelay() (time.Duration, int, bool) {
 	task.mu.Lock()
 	defer task.mu.Unlock()
 
 	if task.retriesRemaining <= 0 {
-		return 0, false
+		return 0, 0, false
 	}
 
-	attempt := task.retriesRemaining
+	attempt := max(task.Retries-task.retriesRemaining+1, 1)
 
 	task.retriesRemaining--
 	if task.retryBackoff <= 0 {
@@ -396,7 +396,7 @@ func (task *Task) nextRetryDelay() (time.Duration, bool) {
 
 	delay = retryJitterDelay(delay, task.ID, attempt)
 
-	return delay, true
+	return delay, attempt, true
 }
 
 func retryJitterDelay(delay time.Duration, id uuid.UUID, attempt int) time.Duration {

--- a/task_retry_jitter_test.go
+++ b/task_retry_jitter_test.go
@@ -20,7 +20,7 @@ func TestRetryJitterDelayWithinBounds(t *testing.T) {
 
 	task.initRetryState(retryJitterTestDelay, 1)
 
-	delay, ok := task.nextRetryDelay()
+	delay, _, ok := task.nextRetryDelay()
 	if !ok {
 		t.Fatal("expected retry delay to be available")
 	}

--- a/tests/hooks_test.go
+++ b/tests/hooks_test.go
@@ -1,0 +1,116 @@
+package tests
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hyp3rd/ewrap"
+
+	"github.com/hyp3rd/go-worker"
+)
+
+const (
+	hookWaitTimeout    = time.Second
+	hookRetryDelay     = 10 * time.Millisecond
+	hookRetryAttempts  = 1
+	hookTasksPerSecond = 1000
+)
+
+func TestTaskManager_Hooks(t *testing.T) {
+	t.Parallel()
+
+	tm := worker.NewTaskManager(context.TODO(), maxWorkers, maxTasks, tasksPerSecond, time.Second*30, time.Second*30, maxRetries)
+
+	var (
+		queued   atomic.Int64
+		started  atomic.Int64
+		finished atomic.Int64
+	)
+
+	tm.SetHooks(worker.TaskHooks{
+		OnQueued: func(_ *worker.Task) { queued.Add(1) },
+		OnStart:  func(_ *worker.Task) { started.Add(1) },
+		OnFinish: func(_ *worker.Task, _ worker.TaskStatus, _ any, _ error) { finished.Add(1) },
+	})
+
+	task := &worker.Task{
+		ID:       uuid.New(),
+		Execute:  func(_ context.Context, _ ...any) (any, error) { return taskName, nil },
+		Priority: 10,
+		Ctx:      context.Background(),
+	}
+
+	err := tm.RegisterTask(context.TODO(), task)
+	if err != nil {
+		t.Fatalf(errMsgFailedRegisterTask, err)
+	}
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), hookWaitTimeout)
+	defer cancel()
+
+	err = tm.Wait(waitCtx)
+	if err != nil {
+		t.Fatalf("Wait returned error: %v", err)
+	}
+
+	if queued.Load() != 1 {
+		t.Fatalf("expected queued hook 1, got %d", queued.Load())
+	}
+
+	if started.Load() != 1 {
+		t.Fatalf("expected start hook 1, got %d", started.Load())
+	}
+
+	if finished.Load() != 1 {
+		t.Fatalf("expected finish hook 1, got %d", finished.Load())
+	}
+}
+
+func TestTaskManager_HookRetry(t *testing.T) {
+	t.Parallel()
+
+	tm := worker.NewTaskManager(context.TODO(), maxWorkers, maxTasks, hookTasksPerSecond, time.Second*30, hookRetryDelay, maxRetries)
+
+	var (
+		retries  atomic.Int64
+		attempts atomic.Int64
+	)
+
+	tm.SetHooks(worker.TaskHooks{
+		OnRetry: func(_ *worker.Task, _ time.Duration, _ int) { retries.Add(1) },
+	})
+
+	task := &worker.Task{
+		ID: uuid.New(),
+		Execute: func(_ context.Context, _ ...any) (any, error) {
+			if attempts.Add(1) == hookRetryAttempts {
+				return nil, ewrap.New("retry")
+			}
+
+			return taskName, nil
+		},
+		Priority: 10,
+		Ctx:      context.Background(),
+		Retries:  hookRetryAttempts,
+	}
+
+	err := tm.RegisterTask(context.TODO(), task)
+	if err != nil {
+		t.Fatalf(errMsgFailedRegisterTask, err)
+	}
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), hookWaitTimeout)
+	defer cancel()
+
+	err = tm.Wait(waitCtx)
+	if err != nil {
+		t.Fatalf("Wait returned error: %v", err)
+	}
+
+	if retries.Load() != 1 {
+		t.Fatalf("expected retry hook 1, got %d", retries.Load())
+	}
+}


### PR DESCRIPTION
…Worker

- Introduce TaskHooks with OnQueued, OnStart, OnFinish, OnRetry and safe runHook (panic recovery).
- Add hooksOperations with SetHooks(TaskHooks); forward SetHooks via middleware/logger.
- Invoke hooks at lifecycle points: enqueue (hookQueued), start (hookStart), retry (hookRetry), finish (hookFinish).
- Adjust retry flow: nextRetryDelay now returns (delay, attempt, ok); update call sites accordingly.
- Add tests (tests/hooks_test.go) covering hook invocation and retry behavior.

This enables external observability/instrumentation around task execution without affecting normal flow.