### PR TITLE
test: add wait error constant and retention TTL coverage

### DIFF
--- a/tests/constants.go
+++ b/tests/constants.go
@@ -1,0 +1,4 @@
+package tests
+
+// ErrMsgWaitReturnedError is the error message format for Wait errors.
+const ErrMsgWaitReturnedError = "Wait returned error: %v"

--- a/tests/hooks_test.go
+++ b/tests/hooks_test.go
@@ -53,7 +53,7 @@ func TestTaskManager_Hooks(t *testing.T) {
 
 	err = tm.Wait(waitCtx)
 	if err != nil {
-		t.Fatalf("Wait returned error: %v", err)
+		t.Fatalf(ErrMsgWaitReturnedError, err)
 	}
 
 	if queued.Load() != 1 {
@@ -107,7 +107,7 @@ func TestTaskManager_HookRetry(t *testing.T) {
 
 	err = tm.Wait(waitCtx)
 	if err != nil {
-		t.Fatalf("Wait returned error: %v", err)
+		t.Fatalf(ErrMsgWaitReturnedError, err)
 	}
 
 	if retries.Load() != 1 {


### PR DESCRIPTION
- Centralize 'Wait returned error: %v' in tests/constants.go and reuse across tests
- Add TaskManager retention TTL test and timing constants
- Make StopGraceful return the worker wait result; add waitWorkers(ctx) with ctx cancellation handling