### PR TITLE
fix(worker): mark retrying tasks as rate-limited and cancel queued/rate-limited tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,4 +199,4 @@ help:
 	@echo
 	@echo
 	@echo "For more information, see the project README."
-.PHONY: prepare-toolchain prepare-proto-tools prepare-base-tools update-toolchain test bench vet update-deps lint sec help run run-container init proto proto-update proto-lint proto-generate proto-format proto-breaking
+.PHONY: prepare-toolchain prepare-proto-tools prepare-base-tools update-toolchain test bench vet update-deps lint sec help init proto proto-update proto-lint proto-generate proto-format proto-breaking

--- a/README.md
+++ b/README.md
@@ -188,6 +188,12 @@ tm.SetHooks(worker.TaskHooks{
 })
 ```
 
+Tracing hooks can be configured with a tracer implementation:
+
+```go
+tm.SetTracer(myTracer)
+```
+
 ### Registering Tasks
 
 Register new tasks by calling the `RegisterTasks()` method of the `TaskManager` struct and passing in a variadic number of tasks.

--- a/cspell.json
+++ b/cspell.json
@@ -55,6 +55,7 @@
     "ewrap",
     "excludeonly",
     "exhaustruct",
+    "fanout",
     "Fprintf",
     "Fprintln",
     "funlen",

--- a/interface.go
+++ b/interface.go
@@ -14,6 +14,7 @@ type Service interface {
 	metricsOperations
 	retentionOperations
 	hooksOperations
+	tracerOperations
 }
 
 type workerOperations interface {
@@ -65,6 +66,11 @@ type retentionOperations interface {
 type hooksOperations interface {
 	// SetHooks configures task lifecycle hooks.
 	SetHooks(hooks TaskHooks)
+}
+
+type tracerOperations interface {
+	// SetTracer configures task tracing.
+	SetTracer(tracer TaskTracer)
 }
 
 // Middleware describes a generic middleware.

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -189,3 +189,8 @@ func (mw *loggerMiddleware) SetRetentionPolicy(policy worker.RetentionPolicy) {
 func (mw *loggerMiddleware) SetHooks(hooks worker.TaskHooks) {
 	mw.next.SetHooks(hooks)
 }
+
+// SetTracer configures task tracing.
+func (mw *loggerMiddleware) SetTracer(tracer worker.TaskTracer) {
+	mw.next.SetTracer(tracer)
+}

--- a/task.go
+++ b/task.go
@@ -304,6 +304,12 @@ func (task *Task) setQueued() {
 	task.mu.Unlock()
 }
 
+func (task *Task) setRateLimited() {
+	task.mu.Lock()
+	task.status = RateLimited
+	task.mu.Unlock()
+}
+
 func (task *Task) markRunning() bool {
 	task.mu.Lock()
 	defer task.mu.Unlock()

--- a/tests/grpc_server_test.go
+++ b/tests/grpc_server_test.go
@@ -1,0 +1,50 @@
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/hyp3rd/go-worker"
+	workerpb "github.com/hyp3rd/go-worker/pkg/worker/v1"
+)
+
+func TestGRPCServer_CancelTaskNotFound(t *testing.T) {
+	t.Parallel()
+
+	tm := worker.NewTaskManager(context.TODO(), maxWorkers, maxTasks, tasksPerSecond, time.Second*30, time.Second*30, maxRetries)
+	server := worker.NewGRPCServer(tm, map[string]worker.HandlerSpec{})
+
+	id := uuid.New().String()
+
+	_, err := server.CancelTask(context.TODO(), &workerpb.CancelTaskRequest{Id: id})
+	if err == nil {
+		t.Fatal("expected error for unknown task")
+	}
+
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("expected NotFound, got %v", status.Code(err))
+	}
+}
+
+func TestGRPCServer_GetTaskNotFound(t *testing.T) {
+	t.Parallel()
+
+	tm := worker.NewTaskManager(context.TODO(), maxWorkers, maxTasks, tasksPerSecond, time.Second*30, time.Second*30, maxRetries)
+	server := worker.NewGRPCServer(tm, map[string]worker.HandlerSpec{})
+
+	id := uuid.New().String()
+
+	_, err := server.GetTask(context.TODO(), &workerpb.GetTaskRequest{Id: id})
+	if err == nil {
+		t.Fatal("expected error for unknown task")
+	}
+
+	if status.Code(err) != codes.NotFound {
+		t.Fatalf("expected NotFound, got %v", status.Code(err))
+	}
+}

--- a/tests/tracer_test.go
+++ b/tests/tracer_test.go
@@ -1,0 +1,77 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hyp3rd/ewrap"
+
+	"github.com/hyp3rd/go-worker"
+)
+
+const tracerWaitTimeout = time.Second
+
+type testSpan struct {
+	ch chan error
+}
+
+func (s testSpan) End(err error) {
+	select {
+	case s.ch <- err:
+	default:
+	}
+}
+
+type testTracer struct {
+	ch chan error
+}
+
+func (t testTracer) Start(ctx context.Context, _ *worker.Task) (context.Context, worker.TaskSpan) {
+	return ctx, t.span()
+}
+
+func (t testTracer) span() testSpan {
+	return testSpan(t)
+}
+
+func TestTaskManager_TracerEnd(t *testing.T) {
+	t.Parallel()
+
+	tm := worker.NewTaskManager(context.TODO(), 1, maxTasks, tasksPerSecond, time.Second*30, time.Second*30, maxRetries)
+
+	errCh := make(chan error, 1)
+	tm.SetTracer(testTracer{ch: errCh})
+
+	taskErr := ewrap.New("trace error")
+	task := &worker.Task{
+		ID:       uuid.New(),
+		Execute:  func(_ context.Context, _ ...any) (any, error) { return nil, taskErr },
+		Priority: 1,
+		Ctx:      context.Background(),
+	}
+
+	err := tm.RegisterTask(context.TODO(), task)
+	if err != nil {
+		t.Fatalf(errMsgFailedRegisterTask, err)
+	}
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), tracerWaitTimeout)
+	defer cancel()
+
+	err = tm.Wait(waitCtx)
+	if err != nil {
+		t.Fatalf(ErrMsgWaitReturnedError, err)
+	}
+
+	select {
+	case got := <-errCh:
+		if !errors.Is(got, taskErr) {
+			t.Fatalf("expected tracer error %v, got %v", taskErr, got)
+		}
+	case <-time.After(tracerWaitTimeout):
+		t.Fatal("timed out waiting for tracer end")
+	}
+}

--- a/tracer.go
+++ b/tracer.go
@@ -1,0 +1,69 @@
+package worker
+
+import (
+	"context"
+	"log/slog"
+)
+
+// TaskSpan represents an in-flight task span.
+type TaskSpan interface {
+	End(err error)
+}
+
+// TaskTracer provides tracing spans around task execution.
+type TaskTracer interface {
+	Start(ctx context.Context, task *Task) (context.Context, TaskSpan)
+}
+
+type tracerHolder struct {
+	tracer TaskTracer
+}
+
+// SetTracer configures the task tracer.
+func (tm *TaskManager) SetTracer(tracer TaskTracer) {
+	if tracer == nil {
+		tm.tracer.Store(nil)
+
+		return
+	}
+
+	tm.tracer.Store(&tracerHolder{tracer: tracer})
+}
+
+func (tm *TaskManager) startSpan(ctx context.Context, task *Task) (context.Context, TaskSpan) {
+	holder := tm.tracer.Load()
+	if holder == nil || holder.tracer == nil {
+		return ctx, nil
+	}
+
+	defer func() {
+		if recover() != nil {
+			// ignore tracer panics
+			logger := slog.Default()
+			logger.Log(tm.ctx, slog.LevelWarn, "tracer panic recovered")
+		}
+	}()
+
+	newCtx, span := holder.tracer.Start(ctx, task)
+	if newCtx == nil {
+		newCtx = ctx
+	}
+
+	return newCtx, span
+}
+
+func (tm *TaskManager) endSpan(span TaskSpan, err error) {
+	if span == nil {
+		return
+	}
+
+	defer func() {
+		if recover() != nil {
+			// ignore tracer panics
+			logger := slog.Default()
+			logger.Log(tm.ctx, slog.LevelWarn, "tracer panic recovered")
+		}
+	}()
+
+	span.End(err)
+}


### PR DESCRIPTION
- Add Task.setRateLimited() helper and use it during scheduleRetry()
- Update CancelTask to also remove/finish tasks in RateLimited state
- Add gRPC server NotFound tests for CancelTask/GetTask and adjust worker fan-out/cancel backoff tests