### PR TITLE
feat(worker): add benchmarks and OTLP/HTTP metrics example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - gRPC auth hook via `WithGRPCAuth`.
 - Task tracing hooks via `TaskTracer`.
 - OpenTelemetry metrics via `SetMeterProvider`.
+- OpenTelemetry tracing example and OTLP metrics example.
+- Result fan-out examples for OTel metrics and tracing.
 - Compatibility shim `GetResults()` for legacy callers.
+- Retention load and OTel metrics wiring tests.
+- Benchmarks for registration throughput and retention pruning.
 
 ### Changed
 
 - Rate limiter burst now defaults to `min(maxWorkers, maxTasks)` for deterministic throttling.
 - `ExecuteTask` respects the task rate limiter (may wait or return context errors).
 - Breaking: `Stop()` removed; use `StopGraceful(ctx)` or `StopNow()`.
-- Breaking: `SubscribeResults` replaces `GetResults()`/`StreamResults()`.
+- Breaking: `SubscribeResults` replaces `GetResults()`/`StreamResults()` (shim restored for legacy).
 - Breaking: `RegisterTasks` now returns an error.
 
 ## [v0.1.1] - 2025-08-18

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ BUF_VERSION ?= v1.64.0
 GO_VERSION ?= 1.25.6
 GCI_PREFIX ?= github.com/hyp3rd/go-worker
 PROTO_ENABLED ?= true
+BENCHTIME ?= 1s
 
 GOFILES = $(shell find . -type f -name '*.go' -not -path "./pkg/api/*" -not -path "./vendor/*" -not -path "./.gocache/*" -not -path "./.git/*")
 
@@ -17,7 +18,7 @@ test-race:
 	go test -race ./...
 
 bench:
-	go test -bench=. -benchtime=3s -benchmem -run=^-memprofile=mem.out ./...
+	go test -bench=. -benchtime=$(BENCHTIME) -benchmem -run=^-memprofile=mem.out ./...
 
 update-deps:
 	go get -v -u ./...

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ if err := tm.SetMeterProvider(mp); err != nil {
 ```
 
 See `__examples/otel_metrics` for a complete runnable example.
+See `__examples/otel_metrics_otlp` for an OTLP/HTTP exporter example.
 
 Emitted metrics:
 

--- a/__examples/otel_metrics_otlp/main.go
+++ b/__examples/otel_metrics_otlp/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"time"
+
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+
+	"github.com/hyp3rd/go-worker"
+)
+
+const (
+	maxWorkers     = 2
+	maxTasks       = 10
+	tasksPerSecond = 5
+	taskTimeout    = 5 * time.Second
+)
+
+func main() {
+	ctx := context.Background()
+
+	endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "http://localhost:4318"
+	}
+
+	exporter, err := otlpmetrichttp.New(ctx,
+		otlpmetrichttp.WithEndpointURL(endpoint),
+		otlpmetrichttp.WithCompression(otlpmetrichttp.GzipCompression),
+	)
+	if err != nil {
+		log.Fatalf("otlp metric exporter: %v", err)
+	}
+
+	reader := sdkmetric.NewPeriodicReader(exporter, sdkmetric.WithInterval(2*time.Second))
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	defer func() {
+		_ = meterProvider.Shutdown(ctx)
+	}()
+
+	tm := worker.NewTaskManager(ctx, maxWorkers, maxTasks, tasksPerSecond, taskTimeout, time.Second, 1)
+	if err := tm.SetMeterProvider(meterProvider); err != nil {
+		log.Fatalf("set meter provider: %v", err)
+	}
+
+	task := &worker.Task{
+		ID:       uuid.New(),
+		Priority: 1,
+		Ctx:      context.Background(),
+		Execute: func(_ context.Context, _ ...any) (any, error) {
+			time.Sleep(100 * time.Millisecond)
+			return "ok", nil
+		},
+	}
+
+	if err := tm.RegisterTask(ctx, task); err != nil {
+		log.Fatalf("register task: %v", err)
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, taskTimeout)
+	defer cancel()
+
+	if err := tm.Wait(waitCtx); err != nil {
+		log.Fatalf("wait: %v", err)
+	}
+
+	if err := meterProvider.ForceFlush(ctx); err != nil {
+		log.Printf("force flush: %v", err)
+	}
+}

--- a/cspell.json
+++ b/cspell.json
@@ -99,6 +99,8 @@
     "nolint",
     "nonamedreturns",
     "nonroot",
+    "otlpmetric",
+    "otlpmetrichttp",
     "pipefail",
     "popd",
     "Println",

--- a/pkg/worker/v1/payload.pb.go
+++ b/pkg/worker/v1/payload.pb.go
@@ -7,11 +7,12 @@
 package workerpb
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -106,10 +107,13 @@ func file_worker_v1_payload_proto_rawDescGZIP() []byte {
 	return file_worker_v1_payload_proto_rawDescData
 }
 
-var file_worker_v1_payload_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
-var file_worker_v1_payload_proto_goTypes = []any{
-	(*SendEmailPayload)(nil), // 0: worker.v1.SendEmailPayload
-}
+var (
+	file_worker_v1_payload_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+	file_worker_v1_payload_proto_goTypes  = []any{
+		(*SendEmailPayload)(nil), // 0: worker.v1.SendEmailPayload
+	}
+)
+
 var file_worker_v1_payload_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
 	0, // [0:0] is the sub-list for method input_type

--- a/pkg/worker/v1/worker.pb.go
+++ b/pkg/worker/v1/worker.pb.go
@@ -7,13 +7,14 @@
 package workerpb
 
 import (
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
+
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	anypb "google.golang.org/protobuf/types/known/anypb"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
 )
 
 const (
@@ -594,21 +595,24 @@ func file_worker_v1_worker_proto_rawDescGZIP() []byte {
 	return file_worker_v1_worker_proto_rawDescData
 }
 
-var file_worker_v1_worker_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
-var file_worker_v1_worker_proto_goTypes = []any{
-	(*Task)(nil),                  // 0: worker.v1.Task
-	(*RegisterTasksRequest)(nil),  // 1: worker.v1.RegisterTasksRequest
-	(*RegisterTasksResponse)(nil), // 2: worker.v1.RegisterTasksResponse
-	(*StreamResultsRequest)(nil),  // 3: worker.v1.StreamResultsRequest
-	(*StreamResultsResponse)(nil), // 4: worker.v1.StreamResultsResponse
-	(*CancelTaskRequest)(nil),     // 5: worker.v1.CancelTaskRequest
-	(*CancelTaskResponse)(nil),    // 6: worker.v1.CancelTaskResponse
-	(*GetTaskRequest)(nil),        // 7: worker.v1.GetTaskRequest
-	(*GetTaskResponse)(nil),       // 8: worker.v1.GetTaskResponse
-	nil,                           // 9: worker.v1.Task.MetadataEntry
-	(*durationpb.Duration)(nil),   // 10: google.protobuf.Duration
-	(*anypb.Any)(nil),             // 11: google.protobuf.Any
-}
+var (
+	file_worker_v1_worker_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+	file_worker_v1_worker_proto_goTypes  = []any{
+		(*Task)(nil),                  // 0: worker.v1.Task
+		(*RegisterTasksRequest)(nil),  // 1: worker.v1.RegisterTasksRequest
+		(*RegisterTasksResponse)(nil), // 2: worker.v1.RegisterTasksResponse
+		(*StreamResultsRequest)(nil),  // 3: worker.v1.StreamResultsRequest
+		(*StreamResultsResponse)(nil), // 4: worker.v1.StreamResultsResponse
+		(*CancelTaskRequest)(nil),     // 5: worker.v1.CancelTaskRequest
+		(*CancelTaskResponse)(nil),    // 6: worker.v1.CancelTaskResponse
+		(*GetTaskRequest)(nil),        // 7: worker.v1.GetTaskRequest
+		(*GetTaskResponse)(nil),       // 8: worker.v1.GetTaskResponse
+		nil,                           // 9: worker.v1.Task.MetadataEntry
+		(*durationpb.Duration)(nil),   // 10: google.protobuf.Duration
+		(*anypb.Any)(nil),             // 11: google.protobuf.Any
+	}
+)
+
 var file_worker_v1_worker_proto_depIdxs = []int32{
 	10, // 0: worker.v1.Task.retry_delay:type_name -> google.protobuf.Duration
 	11, // 1: worker.v1.Task.payload:type_name -> google.protobuf.Any

--- a/pkg/worker/v1/worker_grpc.pb.go
+++ b/pkg/worker/v1/worker_grpc.pb.go
@@ -8,6 +8,7 @@ package workerpb
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -112,12 +113,15 @@ type UnimplementedWorkerServiceServer struct{}
 func (UnimplementedWorkerServiceServer) RegisterTasks(context.Context, *RegisterTasksRequest) (*RegisterTasksResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RegisterTasks not implemented")
 }
+
 func (UnimplementedWorkerServiceServer) StreamResults(*StreamResultsRequest, grpc.ServerStreamingServer[StreamResultsResponse]) error {
 	return status.Error(codes.Unimplemented, "method StreamResults not implemented")
 }
+
 func (UnimplementedWorkerServiceServer) CancelTask(context.Context, *CancelTaskRequest) (*CancelTaskResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CancelTask not implemented")
 }
+
 func (UnimplementedWorkerServiceServer) GetTask(context.Context, *GetTaskRequest) (*GetTaskResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetTask not implemented")
 }

--- a/tests/bench_test.go
+++ b/tests/bench_test.go
@@ -1,0 +1,123 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/hyp3rd/go-worker"
+)
+
+const (
+	benchMaxWorkers          = 4
+	benchMaxTasks            = 1000
+	benchTasksPerSecond      = 1_000_000
+	benchTimeout             = 5 * time.Second
+	benchRetryDelay          = time.Second
+	benchMaxRetries          = 0
+	benchRetentionMaxEntries = 128
+)
+
+func benchBatchSizes() []int {
+	//nolint:revive
+	return []int{1, 10, 100}
+}
+
+func BenchmarkTaskManager_RegisterWait(b *testing.B) {
+	for _, size := range benchBatchSizes() {
+		b.Run(fmt.Sprintf("batch_%d", size), func(b *testing.B) {
+			tm := worker.NewTaskManager(
+				context.Background(),
+				benchMaxWorkers,
+				benchMaxTasks,
+				benchTasksPerSecond,
+				benchTimeout,
+				benchRetryDelay,
+				benchMaxRetries,
+			)
+			tm.SetRetentionPolicy(worker.RetentionPolicy{MaxEntries: benchRetentionMaxEntries})
+			b.Cleanup(func() {
+				tm.StopNow()
+			})
+
+			ctx := context.Background()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for range b.N {
+				tasks := make([]*worker.Task, 0, size)
+				for range size {
+					tasks = append(tasks, newBenchmarkTask())
+				}
+
+				err := tm.RegisterTasks(ctx, tasks...)
+				if err != nil {
+					b.Fatalf("RegisterTasks failed: %v", err)
+				}
+
+				waitCtx, cancel := context.WithTimeout(ctx, benchTimeout)
+
+				err = tm.Wait(waitCtx)
+				if err != nil {
+					cancel()
+					b.Fatalf("Wait failed: %v", err)
+				}
+
+				cancel()
+			}
+		})
+	}
+}
+
+func BenchmarkTaskManager_RetentionMaxEntries(b *testing.B) {
+	tm := worker.NewTaskManager(
+		context.Background(),
+		benchMaxWorkers,
+		benchMaxTasks,
+		benchTasksPerSecond,
+		benchTimeout,
+		benchRetryDelay,
+		benchMaxRetries,
+	)
+	tm.SetRetentionPolicy(worker.RetentionPolicy{MaxEntries: benchRetentionMaxEntries})
+	b.Cleanup(func() {
+		tm.StopNow()
+	})
+
+	ctx := context.Background()
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		taskA := newBenchmarkTask()
+		taskB := newBenchmarkTask()
+
+		err := tm.RegisterTasks(ctx, taskA, taskB)
+		if err != nil {
+			b.Fatalf("RegisterTasks failed: %v", err)
+		}
+
+		waitCtx, cancel := context.WithTimeout(ctx, benchTimeout)
+
+		err = tm.Wait(waitCtx)
+		if err != nil {
+			cancel()
+			b.Fatalf("Wait failed: %v", err)
+		}
+
+		cancel()
+	}
+}
+
+func newBenchmarkTask() *worker.Task {
+	return &worker.Task{
+		ID:       uuid.New(),
+		Priority: 1,
+		Ctx:      context.Background(),
+		Execute:  func(_ context.Context, _ ...any) (any, error) { return nil, nil },
+	}
+}

--- a/worker.go
+++ b/worker.go
@@ -257,16 +257,19 @@ func (tm *TaskManager) RegisterTask(ctx context.Context, task *Task) error {
 		return err
 	}
 
+	tm.wg.Add(1)
+
 	err = tm.enqueue(task)
 	if err != nil {
 		tm.registryMu.Lock()
 		delete(tm.registry, task.ID)
 		tm.registryMu.Unlock()
 
+		tm.wg.Done()
+
 		return err
 	}
 
-	tm.wg.Add(1)
 	task.setQueued()
 	tm.metrics.scheduled.Add(1)
 	tm.hookQueued(task)


### PR DESCRIPTION
- Fix TaskManager RegisterTask waitgroup accounting by incrementing before enqueue and balancing on enqueue failure
- Add benchmark suite for TaskManager register/wait and retention behavior
- Add OTLP/HTTP OpenTelemetry metrics example and document it in README
- Make BENCHTIME configurable in Makefile bench target
- Regenerate/update worker v1 protobuf Go outputs (import/type grouping)