### PR TITLE
feat(durable): add configurable lease renewal and Redis Extend support

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -142,7 +142,7 @@ linters:
           disabled: false
           arguments:
             - max-lit-count: "3"
-              allow-strs: '"","-","key"'
+              allow-strs: '"","-","key","ok"'
               allow-ints: "-1,0,1,2,10,1024,0o600,0o644,0o700,0o755,0666,0755"
               allow-floats: "0.0,1.0"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Retention load and OTel metrics wiring tests.
 - Benchmarks for registration throughput and retention pruning.
 - Durable task APIs with a Redis backend (rueidis).
+- Durable lease renewal via `WithDurableLeaseRenewalInterval`.
 - `NewTaskManagerWithOptions` for functional configuration.
 - gRPC durable task registration via `RegisterDurableTasks`.
 - Durable Redis examples and tooling: `__examples/durable_redis`, `__examples/grpc_durable`, `__examples/durable_dlq_replay`, `__examples/durable_queue_inspect`.
@@ -25,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 - Rate limiter burst now defaults to `min(maxWorkers, maxTasks)` for deterministic throttling.
 - `ExecuteTask` respects the task rate limiter (may wait or return context errors).
+- Breaking: `DurableBackend` now requires `Extend` for lease renewal.
 - Breaking: `Stop()` removed; use `StopGraceful(ctx)` or `StopNow()`.
 - Breaking: `SubscribeResults` replaces `GetResults()`/`StreamResults()` (shim restored for legacy).
 - Breaking: `RegisterTasks` now returns an error.

--- a/__examples/durable_dlq_replay/main.go
+++ b/__examples/durable_dlq_replay/main.go
@@ -88,7 +88,8 @@ func main() {
 			intToString(limit),
 		},
 	)
-	if err := resp.Error(); err != nil {
+	err := resp.Error()
+	if err != nil {
 		log.Fatal(err)
 	}
 

--- a/__examples/grpc_durable/main.go
+++ b/__examples/grpc_durable/main.go
@@ -265,3 +265,11 @@ func (b *loggingBackend) Fail(ctx context.Context, lease worker.DurableTaskLease
 	}
 	return failErr
 }
+
+func (b *loggingBackend) Extend(ctx context.Context, lease worker.DurableTaskLease, duration time.Duration) error {
+	extendErr := b.inner.Extend(ctx, lease, duration)
+	if extendErr != nil {
+		log.Printf("extend error: %v", extendErr)
+	}
+	return extendErr
+}

--- a/cspell.json
+++ b/cspell.json
@@ -164,7 +164,8 @@
     "ZCARD",
     "Zrange",
     "ZRANGEBYSCORE",
-    "ZREM"
+    "ZREM",
+    "ZSCORE"
   ],
   "ignoreWords": [],
   "import": []

--- a/durable_types.go
+++ b/durable_types.go
@@ -71,4 +71,5 @@ type DurableBackend interface {
 	Ack(ctx context.Context, lease DurableTaskLease) error
 	Nack(ctx context.Context, lease DurableTaskLease, delay time.Duration) error
 	Fail(ctx context.Context, lease DurableTaskLease, err error) error
+	Extend(ctx context.Context, lease DurableTaskLease, leaseDuration time.Duration) error
 }

--- a/options.go
+++ b/options.go
@@ -24,6 +24,7 @@ type taskManagerConfig struct {
 	durableLease        time.Duration
 	durablePollInterval time.Duration
 	durableBatchSize    int
+	durableLeaseRenewal time.Duration
 }
 
 func defaultTaskManagerConfig() taskManagerConfig {
@@ -37,6 +38,7 @@ func defaultTaskManagerConfig() taskManagerConfig {
 		durableLease:        defaultDurableLease,
 		durablePollInterval: defaultDurablePollInterval,
 		durableBatchSize:    1,
+		durableLeaseRenewal: 0,
 		durableCodec:        ProtoDurableCodec{},
 	}
 }
@@ -124,5 +126,13 @@ func WithDurablePollInterval(interval time.Duration) TaskManagerOption {
 func WithDurableBatchSize(size int) TaskManagerOption {
 	return func(cfg *taskManagerConfig) {
 		cfg.durableBatchSize = size
+	}
+}
+
+// WithDurableLeaseRenewalInterval sets the interval for renewing durable task leases.
+// Set to <= 0 to disable renewal.
+func WithDurableLeaseRenewalInterval(interval time.Duration) TaskManagerOption {
+	return func(cfg *taskManagerConfig) {
+		cfg.durableLeaseRenewal = interval
 	}
 }

--- a/pkg/worker/v1/payload.pb.go
+++ b/pkg/worker/v1/payload.pb.go
@@ -113,6 +113,7 @@ var (
 		(*SendEmailPayload)(nil), // 0: worker.v1.SendEmailPayload
 	}
 )
+
 var file_worker_v1_payload_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
 	0, // [0:0] is the sub-list for method input_type

--- a/pkg/worker/v1/worker.pb.go
+++ b/pkg/worker/v1/worker.pb.go
@@ -822,6 +822,7 @@ var (
 		(*anypb.Any)(nil),                    // 15: google.protobuf.Any
 	}
 )
+
 var file_worker_v1_worker_proto_depIdxs = []int32{
 	14, // 0: worker.v1.Task.retry_delay:type_name -> google.protobuf.Duration
 	15, // 1: worker.v1.Task.payload:type_name -> google.protobuf.Any

--- a/task.go
+++ b/task.go
@@ -28,6 +28,8 @@ var (
 	ErrTaskAlreadyStarted = ewrap.New("task already started")
 	// ErrTaskCompleted is returned when a task is already completed.
 	ErrTaskCompleted = ewrap.New("task completed")
+	// ErrDurableLeaseNotFound is returned when a durable lease cannot be renewed.
+	ErrDurableLeaseNotFound = ewrap.New("durable lease not found")
 )
 
 const (

--- a/tests/durable_redis_integration_test.go
+++ b/tests/durable_redis_integration_test.go
@@ -1,0 +1,302 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/rueidis"
+
+	worker "github.com/hyp3rd/go-worker"
+)
+
+const (
+	redisEnvAddr     = "REDIS_ADDR"
+	redisEnvPassword = "REDIS_PASSWORD"
+	redisEnvPrefix   = "REDIS_PREFIX"
+	redisScanCount   = 100
+	redisLease       = 2 * time.Second
+	redisNackDelay   = 50 * time.Millisecond
+	redisRetryDelay  = 10 * time.Millisecond
+	redisTestTimeout = 5 * time.Second
+)
+
+func TestRedisDurableBackend_EnqueueDequeueAck(t *testing.T) {
+	t.Parallel()
+
+	addr := os.Getenv(redisEnvAddr)
+	if addr == "" {
+		t.Skipf("%s not set; skipping Redis integration test", redisEnvAddr)
+	}
+
+	password := os.Getenv(redisEnvPassword)
+	prefix := redisTestPrefix(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), redisTestTimeout)
+	defer cancel()
+
+	client := newRedisClient(t, addr, password)
+	defer client.Close()
+
+	cleanupRedisPrefix(ctx, t, client, prefix)
+
+	backend := newRedisBackend(t, client, prefix)
+
+	taskID := uuid.New()
+	task := worker.DurableTask{
+		ID:         taskID,
+		Handler:    "test_handler",
+		Payload:    []byte("payload"),
+		Priority:   1,
+		Retries:    0,
+		RetryDelay: redisRetryDelay,
+		Metadata:   map[string]string{"env": "test"},
+	}
+
+	err := backend.Enqueue(ctx, task)
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	leases, err := backend.Dequeue(ctx, 1, redisLease)
+	if err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+
+	if len(leases) != 1 {
+		t.Fatalf("expected 1 lease, got %d", len(leases))
+	}
+
+	if leases[0].Task.ID != taskID {
+		t.Fatalf("expected task id %s, got %s", taskID, leases[0].Task.ID)
+	}
+
+	err = backend.Ack(ctx, leases[0])
+	if err != nil {
+		t.Fatalf("ack: %v", err)
+	}
+
+	leases, err = backend.Dequeue(ctx, 1, redisLease)
+	if err != nil {
+		t.Fatalf("dequeue after ack: %v", err)
+	}
+
+	if len(leases) != 0 {
+		t.Fatalf("expected no leases after ack, got %d", len(leases))
+	}
+}
+
+func TestRedisDurableBackend_NackRequeues(t *testing.T) {
+	t.Parallel()
+
+	addr := os.Getenv(redisEnvAddr)
+	if addr == "" {
+		t.Skipf("%s not set; skipping Redis integration test", redisEnvAddr)
+	}
+
+	password := os.Getenv(redisEnvPassword)
+	prefix := redisTestPrefix(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), redisTestTimeout)
+	defer cancel()
+
+	client := newRedisClient(t, addr, password)
+	defer client.Close()
+
+	cleanupRedisPrefix(ctx, t, client, prefix)
+
+	backend := newRedisBackend(t, client, prefix)
+
+	taskID := uuid.New()
+	task := worker.DurableTask{
+		ID:         taskID,
+		Handler:    "test_handler",
+		Payload:    []byte("payload"),
+		Priority:   1,
+		Retries:    1,
+		RetryDelay: redisRetryDelay,
+	}
+
+	err := backend.Enqueue(ctx, task)
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	leases, err := backend.Dequeue(ctx, 1, redisLease)
+	if err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+
+	if len(leases) != 1 {
+		t.Fatalf("expected 1 lease, got %d", len(leases))
+	}
+
+	err = backend.Nack(ctx, leases[0], redisNackDelay)
+	if err != nil {
+		t.Fatalf("nack: %v", err)
+	}
+
+	leases, err = backend.Dequeue(ctx, 1, redisLease)
+	if err != nil {
+		t.Fatalf("dequeue after nack: %v", err)
+	}
+
+	if len(leases) != 0 {
+		t.Fatalf("expected no leases before delay, got %d", len(leases))
+	}
+
+	time.Sleep(redisNackDelay + 10*time.Millisecond)
+
+	leases, err = backend.Dequeue(ctx, 1, redisLease)
+	if err != nil {
+		t.Fatalf("dequeue after delay: %v", err)
+	}
+
+	if len(leases) != 1 {
+		t.Fatalf("expected 1 lease after delay, got %d", len(leases))
+	}
+}
+
+func TestRedisDurableBackend_FailMovesToDLQ(t *testing.T) {
+	t.Parallel()
+
+	addr := os.Getenv(redisEnvAddr)
+	if addr == "" {
+		t.Skipf("%s not set; skipping Redis integration test", redisEnvAddr)
+	}
+
+	password := os.Getenv(redisEnvPassword)
+	prefix := redisTestPrefix(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), redisTestTimeout)
+	defer cancel()
+
+	client := newRedisClient(t, addr, password)
+	defer client.Close()
+
+	cleanupRedisPrefix(ctx, t, client, prefix)
+
+	backend := newRedisBackend(t, client, prefix)
+
+	taskID := uuid.New()
+	task := worker.DurableTask{
+		ID:         taskID,
+		Handler:    "test_handler",
+		Payload:    []byte("payload"),
+		Priority:   1,
+		Retries:    0,
+		RetryDelay: redisRetryDelay,
+	}
+
+	err := backend.Enqueue(ctx, task)
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	leases, err := backend.Dequeue(ctx, 1, redisLease)
+	if err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+
+	if len(leases) != 1 {
+		t.Fatalf("expected 1 lease, got %d", len(leases))
+	}
+
+	err = backend.Fail(ctx, leases[0], errTestBoom)
+	if err != nil {
+		t.Fatalf("fail: %v", err)
+	}
+
+	deadKey := redisKeyPrefix(prefix) + ":dead"
+
+	deadCount, err := client.Do(ctx, client.B().Llen().Key(deadKey).Build()).AsInt64()
+	if err != nil {
+		t.Fatalf("dead count: %v", err)
+	}
+
+	if deadCount == 0 {
+		t.Fatal("expected dead letter list to contain entries")
+	}
+}
+
+func newRedisClient(t *testing.T, addr, password string) rueidis.Client {
+	t.Helper()
+
+	client, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress: []string{addr},
+		Password:    password,
+	})
+	if err != nil {
+		t.Fatalf("redis client: %v", err)
+	}
+
+	return client
+}
+
+func newRedisBackend(t *testing.T, client rueidis.Client, prefix string) *worker.RedisDurableBackend {
+	t.Helper()
+
+	backend, err := worker.NewRedisDurableBackend(client, worker.WithRedisDurablePrefix(prefix))
+	if err != nil {
+		t.Fatalf("redis backend: %v", err)
+	}
+
+	return backend
+}
+
+func cleanupRedisPrefix(ctx context.Context, t *testing.T, client rueidis.Client, prefix string) {
+	t.Helper()
+
+	cursor := uint64(0)
+	pattern := redisKeyPrefix(prefix) + ":*"
+
+	for {
+		resp := client.Do(ctx, client.B().Scan().Cursor(cursor).Match(pattern).Count(redisScanCount).Build())
+
+		entry, err := resp.AsScanEntry()
+		if err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+
+		if len(entry.Elements) > 0 {
+			del := client.B().Del().Key(entry.Elements...).Build()
+
+			err := client.Do(ctx, del).Error()
+			if err != nil {
+				t.Fatalf("del: %v", err)
+			}
+		}
+
+		if entry.Cursor == 0 {
+			break
+		}
+
+		cursor = entry.Cursor
+	}
+}
+
+func redisKeyPrefix(prefix string) string {
+	if prefix == "" {
+		return "go-worker"
+	}
+
+	if strings.Contains(prefix, "{") {
+		return prefix
+	}
+
+	return "{" + prefix + "}"
+}
+
+func redisTestPrefix(t *testing.T) string {
+	t.Helper()
+
+	base := os.Getenv(redisEnvPrefix)
+	if base == "" {
+		base = "go-worker-test"
+	}
+
+	return base + "-" + uuid.NewString()
+}

--- a/tests/grpc_idempotency_test.go
+++ b/tests/grpc_idempotency_test.go
@@ -208,3 +208,7 @@ func (*idempotencyDurableBackend) Nack(context.Context, worker.DurableTaskLease,
 func (*idempotencyDurableBackend) Fail(context.Context, worker.DurableTaskLease, error) error {
 	return nil
 }
+
+func (*idempotencyDurableBackend) Extend(context.Context, worker.DurableTaskLease, time.Duration) error {
+	return nil
+}


### PR DESCRIPTION
Add WithDurableLeaseRenewalInterval and wire it through TaskManager config to periodically extend durable leases for long-running tasks. Extend the DurableBackend interface with Extend(), implement it in Redis via a Lua script, and document the renewal requirement. Includes changelog/docs updates and new/updated tests around Redis durability and lease renewal behavior.