### PR TITLE
feat(examples): make DLQ replay dry-run by default and add timeouts/ID display

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -142,7 +142,7 @@ linters:
           disabled: false
           arguments:
             - max-lit-count: "3"
-              allow-strs: '"","-","key","ok"'
+              allow-strs: '"","-","key","ok","%s: %v"'
               allow-ints: "-1,0,1,2,10,1024,0o600,0o644,0o700,0o755,0666,0755"
               allow-floats: "0.0,1.0"
 

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,11 @@ test:
 	RUN_INTEGRATION_TEST=yes go test -v -timeout 5m -cover ./...
 
 test-integration:
-	docker compose -f $(REDIS_TEST_COMPOSE_FILE) up -d && \
-	RUN_INTEGRATION_TEST=yes REDIS_ADDR=$(REDIS_ADDR) REDIS_PASSWORD=$(REDIS_PASSWORD) REDIS_PREFIX=$(REDIS_PREFIX) go test -v -timeout 5m -cover ./... || \
-	docker compose -f $(REDIS_TEST_COMPOSE_FILE) down
+	docker compose -f $(REDIS_TEST_COMPOSE_FILE) up -d; \
+	EXIT_CODE=0; \
+	RUN_INTEGRATION_TEST=yes REDIS_ADDR=$(REDIS_ADDR) REDIS_PASSWORD=$(REDIS_PASSWORD) REDIS_PREFIX=$(REDIS_PREFIX) go test -v -timeout 5m -cover ./... || EXIT_CODE=$$?; \
+	docker compose -f $(REDIS_TEST_COMPOSE_FILE) down; \
+	exit $$EXIT_CODE
 
 test-race:
 	go test -race ./...
@@ -196,7 +198,7 @@ help:
 	@echo
 	@echo "Testing commands:"
 	@echo "  test\t\t\t\tRun all tests in the project"
-	@echo "  test-integration\t\tRun all integration tests (requires external services
+	@echo "  test-integration\t\tRun all integration tests (requires external services)"
 	@echo
 	@echo "Code quality commands:"
 	@echo "  lint\t\t\t\tRun all linters (gci, gofumpt, staticcheck, golangci-lint)"

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ GO_VERSION ?= 1.25.6
 GCI_PREFIX ?= github.com/hyp3rd/go-worker
 PROTO_ENABLED ?= true
 BENCHTIME ?= 1s
+REDIS_ADDR ?= localhost:6380
+REDIS_PASSWORD ?= "supersecret"
+REDIS_PREFIX ?= test_prefix_
+REDIS_TEST_COMPOSE_FILE ?= ./__examples/durable_redis/compose.redis-stack.yaml
 
 GOFILES = $(shell find . -type f -name '*.go' -not -path "./pkg/api/*" -not -path "./vendor/*" -not -path "./.gocache/*" -not -path "./.git/*")
 
@@ -13,6 +17,11 @@ GOFILES = $(shell find . -type f -name '*.go' -not -path "./pkg/api/*" -not -pat
 
 test:
 	RUN_INTEGRATION_TEST=yes go test -v -timeout 5m -cover ./...
+
+test-integration:
+	docker compose -f $(REDIS_TEST_COMPOSE_FILE) up -d && \
+	RUN_INTEGRATION_TEST=yes REDIS_ADDR=$(REDIS_ADDR) REDIS_PASSWORD=$(REDIS_PASSWORD) REDIS_PREFIX=$(REDIS_PREFIX) go test -v -timeout 5m -cover ./... || \
+	docker compose -f $(REDIS_TEST_COMPOSE_FILE) down
 
 test-race:
 	go test -race ./...
@@ -187,6 +196,7 @@ help:
 	@echo
 	@echo "Testing commands:"
 	@echo "  test\t\t\t\tRun all tests in the project"
+	@echo "  test-integration\t\tRun all integration tests (requires external services
 	@echo
 	@echo "Code quality commands:"
 	@echo "  lint\t\t\t\tRun all linters (gci, gofumpt, staticcheck, golangci-lint)"
@@ -200,4 +210,4 @@ help:
 	@echo
 	@echo
 	@echo "For more information, see the project README."
-.PHONY: prepare-toolchain prepare-proto-tools prepare-base-tools update-toolchain test bench vet update-deps lint sec help init proto proto-update proto-lint proto-generate proto-format proto-breaking
+.PHONY: prepare-toolchain prepare-proto-tools prepare-base-tools update-toolchain test test-integration bench vet update-deps lint sec help init proto proto-update proto-lint proto-generate proto-format proto-breaking

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ srv := worker.NewGRPCServer(tm, handlers)
 For production, configure TLS credentials and interceptors (logging/auth) on the gRPC server; see `__examples/grpc` for a complete setup.
 For a Redis-backed durable gRPC example, see `__examples/grpc_durable`.
 
+Security defaults to follow in production:
+
+- Use TLS (prefer mTLS) for gRPC; the durable gRPC example uses insecure credentials for local demos only.
+- Scrub payloads and auth metadata from logs; log task IDs or correlation IDs instead of PII.
+- Implement auth via `WithGRPCAuth` and redact/validate tokens inside interceptors.
+
 ### Durable gRPC client (example)
 
 Use `RegisterDurableTasks` for persisted tasks (payload is still `Any`). Results stream is shared with non-durable tasks.
@@ -280,7 +286,7 @@ Operational notes (durable Redis):
 - **Multi-node workers**: Multiple workers can safely dequeue from the same backend. Lease timeouts handle worker crashes, but tune `WithDurableLease` for your workload.
 - **Lease renewal**: enable `WithDurableLeaseRenewalInterval` for long-running tasks to extend leases while a task executes.
 - **Visibility**: Ready and processing queues live in sorted sets; you can inspect sizes via `ZCARD` on `{prefix}:ready` and `{prefix}:processing`.
-- **Inspect utility**: `__examples/durable_queue_inspect` prints ready/processing/dead counts and peeks ready IDs.
+- **Inspect utility**: `__examples/durable_queue_inspect` prints ready/processing/dead counts; use `-show-ids` to display IDs (hidden by default to avoid leaking sensitive identifiers).
 
 ### Multi-node coordination (durable Redis)
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@
 ## Breaking changes (January 2026)
 
 - `Stop()` removed. Use `StopGraceful(ctx)` or `StopNow()`.
-- Local result streaming uses `SubscribeResults(buffer)`; `GetResults()` is now a compatibility shim and `StreamResults()` is removed.
+- Local result streaming uses `SubscribeResults(buffer)`; `GetResults()` is now a compatibility shim and the legacy local `StreamResults()` is removed (gRPC `StreamResults` remains).
 - `RegisterTasks` now returns an error.
 - `Task.Execute` replaces `Fn` in examples.
 - `NewGRPCServer` requires a handler map.
 - Rate limiting is deterministic: burst is `min(maxWorkers, maxTasks)` and `ExecuteTask` uses the shared limiter.
 - gRPC durable tasks use `RegisterDurableTasks` and the new `DurableTask` message.
+- When a durable backend is configured, use `RegisterDurableTask(s)` instead of `RegisterTask(s)`.
 - `DurableBackend` now requires `Extend` (lease renewal support for custom backends).
 
 ## Features
@@ -23,7 +24,7 @@
 - Results: fan-out subscriptions via `SubscribeResults`.
 - Cancellation: cancel tasks before or during execution.
 - Retries: exponential backoff with capped delays.
-- Durability: optional Redis-backed durable task queue.
+- Durability: optional Redis-backed durable task queue (at-least-once, lease-based).
 
 ## Architecture
 

--- a/__examples/durable_queue_inspect/main.go
+++ b/__examples/durable_queue_inspect/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/redis/rueidis"
 )

--- a/__examples/durable_redis/main.go
+++ b/__examples/durable_redis/main.go
@@ -50,8 +50,8 @@ func main() {
 		"send_email": {
 			Make: func() proto.Message { return &workerpb.SendEmailPayload{} },
 			Fn: func(ctx context.Context, payload proto.Message) (any, error) {
-				req := payload.(*workerpb.SendEmailPayload)
-				log.Printf("send email to=%s subject=%s", req.To, req.Subject)
+				_ = payload.(*workerpb.SendEmailPayload)
+				log.Printf("send_email handler invoked")
 				if *failOnce {
 					*failOnce = false
 					return nil, errors.New("forced failure")

--- a/__examples/grpc/main.go
+++ b/__examples/grpc/main.go
@@ -45,8 +45,9 @@ func handlers() map[string]worker.HandlerSpec {
 				if !ok {
 					return nil, status.Errorf(codes.InvalidArgument, "invalid payload type")
 				}
+				_ = in
 				// do work...
-				return fmt.Sprintf("email sent to %s with subject %s", in.GetTo(), in.GetSubject()), nil
+				return "ok", nil
 			},
 		},
 		// Other Tasks:
@@ -306,6 +307,6 @@ func main() {
 			continue
 		}
 
-		log.Printf("task %s output: %s", msg.GetId(), msg.GetOutput())
+		log.Printf("task %s completed", msg.GetId())
 	}
 }

--- a/__examples/grpc_durable/main.go
+++ b/__examples/grpc_durable/main.go
@@ -65,8 +65,8 @@ func main() {
 		"send_email": {
 			Make: func() proto.Message { return &workerpb.SendEmailPayload{} },
 			Fn: func(ctx context.Context, payload proto.Message) (any, error) {
-				msg := payload.(*workerpb.SendEmailPayload)
-				log.Printf("send email to=%s subject=%s", msg.To, msg.Subject)
+				_ = payload.(*workerpb.SendEmailPayload)
+				log.Printf("send_email handler invoked")
 				return "ok", nil
 			},
 		},
@@ -76,8 +76,8 @@ func main() {
 		"send_email": {
 			Make: func() protoreflect.ProtoMessage { return &workerpb.SendEmailPayload{} },
 			Fn: func(ctx context.Context, payload protoreflect.ProtoMessage) (any, error) {
-				msg := payload.(*workerpb.SendEmailPayload)
-				log.Printf("grpc handler send email to=%s subject=%s", msg.To, msg.Subject)
+				_ = payload.(*workerpb.SendEmailPayload)
+				log.Printf("grpc handler send_email invoked")
 				return "ok", nil
 			},
 		},
@@ -113,6 +113,7 @@ func main() {
 	dialCtx, dialCancel := context.WithTimeout(ctx, dialTimeout)
 	defer dialCancel()
 
+	// NOTE: insecure transport is for local demos only; use TLS credentials in production.
 	conn, err := grpc.DialContext(dialCtx, grpcAddr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
 	if err != nil {
 		log.Fatal(err)
@@ -168,7 +169,7 @@ func main() {
 			break
 		}
 		if msg.Id == targetID {
-			log.Printf("result id=%s output=%s error=%s", msg.Id, msg.Output, msg.Error)
+			log.Printf("result id=%s error=%s", msg.Id, msg.Error)
 			break
 		}
 	}

--- a/cspell.json
+++ b/cspell.json
@@ -50,6 +50,7 @@
     "depguard",
     "distroless",
     "dotenv",
+    "dupword",
     "durationpb",
     "EDITMSG",
     "elif",

--- a/tests/grpc_server_test.go
+++ b/tests/grpc_server_test.go
@@ -31,6 +31,22 @@ func TestGRPCServer_CancelTaskNotFound(t *testing.T) {
 	}
 }
 
+func TestGRPCServer_CancelTaskInvalidID(t *testing.T) {
+	t.Parallel()
+
+	tm := worker.NewTaskManager(context.TODO(), maxWorkers, maxTasks, tasksPerSecond, time.Second*30, time.Second*30, maxRetries)
+	server := worker.NewGRPCServer(tm, map[string]worker.HandlerSpec{})
+
+	_, err := server.CancelTask(context.TODO(), &workerpb.CancelTaskRequest{Id: "not-a-uuid"})
+	if err == nil {
+		t.Fatal("expected error for invalid task id")
+	}
+
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %v", status.Code(err))
+	}
+}
+
 func TestGRPCServer_GetTaskNotFound(t *testing.T) {
 	t.Parallel()
 
@@ -46,6 +62,22 @@ func TestGRPCServer_GetTaskNotFound(t *testing.T) {
 
 	if status.Code(err) != codes.NotFound {
 		t.Fatalf("expected NotFound, got %v", status.Code(err))
+	}
+}
+
+func TestGRPCServer_GetTaskInvalidID(t *testing.T) {
+	t.Parallel()
+
+	tm := worker.NewTaskManager(context.TODO(), maxWorkers, maxTasks, tasksPerSecond, time.Second*30, time.Second*30, maxRetries)
+	server := worker.NewGRPCServer(tm, map[string]worker.HandlerSpec{})
+
+	_, err := server.GetTask(context.TODO(), &workerpb.GetTaskRequest{Id: "not-a-uuid"})
+	if err == nil {
+		t.Fatal("expected error for invalid task id")
+	}
+
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %v", status.Code(err))
 	}
 }
 


### PR DESCRIPTION
- Change DLQ replay example to default to dry-run; require -apply to perform replay
- Add -timeout flag (default 5s) and use context.WithTimeout for Redis ops in DLQ replay + queue inspect examples
- Add -show-ids flag to durable queue inspect example to optionally print ready task IDs
- Update README to document new DLQ replay behavior and add queue inspect usage examples