### PR TITLE
feat: add typed handler registries for gRPC and durable tasks

### DIFF
--- a/__examples/durable_redis/main.go
+++ b/__examples/durable_redis/main.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"log"
 	"time"
 
+	"github.com/hyp3rd/ewrap"
 	"github.com/redis/rueidis"
 	"google.golang.org/protobuf/proto"
 
@@ -54,7 +54,7 @@ func main() {
 				log.Printf("send_email handler invoked")
 				if *failOnce {
 					*failOnce = false
-					return nil, errors.New("forced failure")
+					return nil, ewrap.New("forced failure")
 				}
 				return "ok", nil
 			},

--- a/tests/durable_test.go
+++ b/tests/durable_test.go
@@ -2,12 +2,12 @@ package tests
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/hyp3rd/ewrap"
 	"google.golang.org/protobuf/proto"
 
 	worker "github.com/hyp3rd/go-worker"
@@ -22,7 +22,7 @@ const (
 	errMarshalPayload = "marshal payload: %v"
 )
 
-var errTestBoom = errors.New("boom")
+var errTestBoom = ewrap.New("boom")
 
 type fakeDurableBackend struct {
 	mu        sync.Mutex

--- a/tests/typed_registry_test.go
+++ b/tests/typed_registry_test.go
@@ -1,0 +1,138 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/hyp3rd/ewrap"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	worker "github.com/hyp3rd/go-worker"
+	workerpb "github.com/hyp3rd/go-worker/pkg/worker/v1"
+)
+
+func assertTypedHandlerInvocation(
+	t *testing.T,
+	specFn func(context.Context, any) (any, error),
+) {
+	t.Helper()
+
+	result, err := specFn(context.Background(), &workerpb.SendEmailPayload{})
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	if result != "ok" {
+		t.Fatalf("expected result ok, got %v", result)
+	}
+
+	_, err = specFn(context.Background(), &workerpb.Task{})
+	if !errors.Is(err, worker.ErrHandlerPayloadTypeMismatch) {
+		t.Fatalf("expected ErrHandlerPayloadTypeMismatch, got %v", err)
+	}
+}
+
+func TestTypedHandlerConversions(t *testing.T) {
+	t.Parallel()
+
+	makeSpec := func() worker.TypedHandlerSpec[*workerpb.SendEmailPayload] {
+		return worker.TypedHandlerSpec[*workerpb.SendEmailPayload]{
+			Make: func() *workerpb.SendEmailPayload { return &workerpb.SendEmailPayload{} },
+			Fn: func(_ context.Context, payload *workerpb.SendEmailPayload) (any, error) {
+				if payload == nil {
+					return nil, ewrap.New("missing payload")
+				}
+
+				return "ok", nil
+			},
+		}
+	}
+
+	cases := []struct {
+		name   string
+		specFn func(context.Context, any) (any, error)
+	}{
+		{
+			name: "grpc",
+			specFn: func(ctx context.Context, payload any) (any, error) {
+				spec := worker.TypedHandler(makeSpec())
+
+				p, ok := payload.(protoreflect.ProtoMessage)
+				if !ok {
+					return nil, worker.ErrHandlerPayloadTypeMismatch
+				}
+
+				return spec.Fn(ctx, p)
+			},
+		},
+		{
+			name: "durable",
+			specFn: func(ctx context.Context, payload any) (any, error) {
+				spec := worker.TypedDurableHandler(worker.TypedDurableHandlerSpec[*workerpb.SendEmailPayload]{
+					Make: func() *workerpb.SendEmailPayload { return &workerpb.SendEmailPayload{} },
+					Fn: func(_ context.Context, payload *workerpb.SendEmailPayload) (any, error) {
+						if payload == nil {
+							return nil, ewrap.New("missing payload")
+						}
+
+						return "ok", nil
+					},
+				})
+
+				p, ok := payload.(protoreflect.ProtoMessage)
+				if !ok {
+					return nil, worker.ErrHandlerPayloadTypeMismatch
+				}
+
+				return spec.Fn(ctx, p)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assertTypedHandlerInvocation(t, tc.specFn)
+		})
+	}
+}
+
+func TestTypedRegistry_DuplicateHandler(t *testing.T) {
+	t.Parallel()
+
+	registry := worker.NewTypedHandlerRegistry()
+
+	err := worker.AddTypedHandler(registry, "send_email", worker.TypedHandlerSpec[*workerpb.SendEmailPayload]{
+		Make: func() *workerpb.SendEmailPayload { return &workerpb.SendEmailPayload{} },
+		Fn: func(_ context.Context, _ *workerpb.SendEmailPayload) (any, error) {
+			return "ok", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Add returned error: %v", err)
+	}
+
+	err = worker.AddTypedHandler(registry, "send_email", worker.TypedHandlerSpec[*workerpb.SendEmailPayload]{
+		Make: func() *workerpb.SendEmailPayload { return &workerpb.SendEmailPayload{} },
+		Fn: func(_ context.Context, _ *workerpb.SendEmailPayload) (any, error) {
+			return "ok", nil
+		},
+	})
+	if !errors.Is(err, worker.ErrHandlerAlreadyRegistered) {
+		t.Fatalf("expected ErrHandlerAlreadyRegistered, got %v", err)
+	}
+
+	durableRegistry := worker.NewTypedDurableRegistry()
+
+	err = worker.AddTypedDurableHandler(durableRegistry, "send_email", worker.TypedDurableHandlerSpec[*workerpb.SendEmailPayload]{
+		Make: func() *workerpb.SendEmailPayload { return &workerpb.SendEmailPayload{} },
+		Fn: func(_ context.Context, _ *workerpb.SendEmailPayload) (any, error) {
+			return "ok", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Add durable handler returned error: %v", err)
+	}
+}

--- a/typed_registry.go
+++ b/typed_registry.go
@@ -1,0 +1,197 @@
+package worker
+
+import (
+	"context"
+	"maps"
+
+	"github.com/hyp3rd/ewrap"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+var (
+	// ErrHandlerNameRequired indicates a missing handler name during registration.
+	ErrHandlerNameRequired = ewrap.New("handler name is required")
+	// ErrHandlerSpecInvalid indicates an invalid handler spec during registration.
+	ErrHandlerSpecInvalid = ewrap.New("handler spec is invalid")
+	// ErrHandlerAlreadyRegistered indicates a duplicate handler name during registration.
+	ErrHandlerAlreadyRegistered = ewrap.New("handler already registered")
+	// ErrHandlerPayloadTypeMismatch indicates a payload type mismatch during handler invocation.
+	ErrHandlerPayloadTypeMismatch = ewrap.New("handler payload type mismatch")
+	// ErrHandlerRegistryNil indicates a nil handler registry during registration.
+	ErrHandlerRegistryNil = ewrap.New("handler registry is nil")
+)
+
+// TypedHandlerSpec provides a compile-time checked handler signature for gRPC tasks.
+type TypedHandlerSpec[T protoreflect.ProtoMessage] struct {
+	Make func() T
+	Fn   func(ctx context.Context, payload T) (any, error)
+}
+
+// TypedHandlerRegistry collects typed gRPC handlers and exposes the untyped map.
+type TypedHandlerRegistry struct {
+	handlers map[string]HandlerSpec
+}
+
+// NewTypedHandlerRegistry constructs a registry for typed gRPC handlers.
+func NewTypedHandlerRegistry() *TypedHandlerRegistry {
+	return &TypedHandlerRegistry{
+		handlers: make(map[string]HandlerSpec),
+	}
+}
+
+// Add registers an untyped handler spec into the registry.
+func (r *TypedHandlerRegistry) Add(name string, spec HandlerSpec) error {
+	if r == nil {
+		return ErrHandlerRegistryNil
+	}
+
+	return r.register(name, spec)
+}
+
+// Handlers returns a defensive copy of the registered handler map.
+func (r *TypedHandlerRegistry) Handlers() map[string]HandlerSpec {
+	if len(r.handlers) == 0 {
+		return map[string]HandlerSpec{}
+	}
+
+	out := make(map[string]HandlerSpec, len(r.handlers))
+	maps.Copy(out, r.handlers)
+
+	return out
+}
+
+func (r *TypedHandlerRegistry) register(name string, spec HandlerSpec) error {
+	if name == "" {
+		return ErrHandlerNameRequired
+	}
+
+	if spec.Make == nil || spec.Fn == nil {
+		return ErrHandlerSpecInvalid
+	}
+
+	if r.handlers == nil {
+		r.handlers = make(map[string]HandlerSpec)
+	}
+
+	if _, exists := r.handlers[name]; exists {
+		return ewrap.Wrapf(ErrHandlerAlreadyRegistered, "handler %q", name)
+	}
+
+	r.handlers[name] = spec
+
+	return nil
+}
+
+// AddTypedHandler registers a typed handler spec into the registry.
+func AddTypedHandler[T protoreflect.ProtoMessage](r *TypedHandlerRegistry, name string, spec TypedHandlerSpec[T]) error {
+	if r == nil {
+		return ErrHandlerRegistryNil
+	}
+
+	return r.register(name, TypedHandler(spec))
+}
+
+// TypedHandler converts a typed spec into the untyped HandlerSpec.
+func TypedHandler[T protoreflect.ProtoMessage](spec TypedHandlerSpec[T]) HandlerSpec {
+	return HandlerSpec{
+		Make: func() protoreflect.ProtoMessage {
+			return spec.Make()
+		},
+		Fn: func(ctx context.Context, payload protoreflect.ProtoMessage) (any, error) {
+			typed, ok := payload.(T)
+			if !ok {
+				return nil, ErrHandlerPayloadTypeMismatch
+			}
+
+			return spec.Fn(ctx, typed)
+		},
+	}
+}
+
+// TypedDurableHandlerSpec provides a compile-time checked handler signature for durable tasks.
+type TypedDurableHandlerSpec[T proto.Message] struct {
+	Make func() T
+	Fn   func(ctx context.Context, payload T) (any, error)
+}
+
+// TypedDurableRegistry collects typed durable handlers and exposes the untyped map.
+type TypedDurableRegistry struct {
+	handlers map[string]DurableHandlerSpec
+}
+
+// NewTypedDurableRegistry constructs a registry for typed durable handlers.
+func NewTypedDurableRegistry() *TypedDurableRegistry {
+	return &TypedDurableRegistry{
+		handlers: make(map[string]DurableHandlerSpec),
+	}
+}
+
+// Add registers an untyped durable handler spec into the registry.
+func (r *TypedDurableRegistry) Add(name string, spec DurableHandlerSpec) error {
+	if r == nil {
+		return ErrHandlerRegistryNil
+	}
+
+	return r.register(name, spec)
+}
+
+// Handlers returns a defensive copy of the registered durable handler map.
+func (r *TypedDurableRegistry) Handlers() map[string]DurableHandlerSpec {
+	if len(r.handlers) == 0 {
+		return map[string]DurableHandlerSpec{}
+	}
+
+	out := make(map[string]DurableHandlerSpec, len(r.handlers))
+	maps.Copy(out, r.handlers)
+
+	return out
+}
+
+func (r *TypedDurableRegistry) register(name string, spec DurableHandlerSpec) error {
+	if name == "" {
+		return ErrHandlerNameRequired
+	}
+
+	if spec.Make == nil || spec.Fn == nil {
+		return ErrHandlerSpecInvalid
+	}
+
+	if r.handlers == nil {
+		r.handlers = make(map[string]DurableHandlerSpec)
+	}
+
+	if _, exists := r.handlers[name]; exists {
+		return ewrap.Wrapf(ErrHandlerAlreadyRegistered, "durable handler %q", name)
+	}
+
+	r.handlers[name] = spec
+
+	return nil
+}
+
+// AddTypedDurableHandler registers a typed durable handler spec into the registry.
+func AddTypedDurableHandler[T proto.Message](r *TypedDurableRegistry, name string, spec TypedDurableHandlerSpec[T]) error {
+	if r == nil {
+		return ErrHandlerRegistryNil
+	}
+
+	return r.register(name, TypedDurableHandler(spec))
+}
+
+// TypedDurableHandler converts a typed spec into the untyped DurableHandlerSpec.
+func TypedDurableHandler[T proto.Message](spec TypedDurableHandlerSpec[T]) DurableHandlerSpec {
+	return DurableHandlerSpec{
+		Make: func() proto.Message {
+			return spec.Make()
+		},
+		Fn: func(ctx context.Context, payload proto.Message) (any, error) {
+			typed, ok := payload.(T)
+			if !ok {
+				return nil, ErrHandlerPayloadTypeMismatch
+			}
+
+			return spec.Fn(ctx, typed)
+		},
+	}
+}


### PR DESCRIPTION
Introduce generic (typed) registries and specs with adapters back to existing untyped HandlerSpec/DurableHandlerSpec, including validation and clear error cases. Update docs, examples, and tests to cover typed registration, duplicate handling, and error paths, and switch tests/examples to ewrap.New for failures.