### PR TITLE
feat(workerctl): add durable requeue/delete/stats commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,10 +364,29 @@ Requeue tasks from a source set (DLQ/ready/processing):
 ./workerctl durable retry --source ready --from-queue default --limit 50 --apply
 ```
 
+Requeue a queue directly (shortcut):
+
+```bash
+./workerctl durable requeue --queue default --limit 50 --apply
+```
+
 Fetch a task by ID:
 
 ```bash
 ./workerctl durable get --id 8c0f8b2d-0a4d-4a3b-9ad7-2d2a5b7f5d12
+```
+
+Delete a task (and optionally its hash):
+
+```bash
+./workerctl durable delete --id 8c0f8b2d-0a4d-4a3b-9ad7-2d2a5b7f5d12 --apply
+./workerctl durable delete --id 8c0f8b2d-0a4d-4a3b-9ad7-2d2a5b7f5d12 --delete-hash --apply
+```
+
+Show stats in JSON:
+
+```bash
+./workerctl durable stats --json
 ```
 
 Purge queues (use with care):

--- a/cmd/workerctl/durable.go
+++ b/cmd/workerctl/durable.go
@@ -12,8 +12,11 @@ func newDurableCmd(cfg *redisConfig) *cobra.Command {
 		newDurableInspectCmd(cfg),
 		newDurableDLQCmd(cfg),
 		newDurableRetryCmd(cfg),
+		newDurableRequeueCmd(cfg),
 		newDurablePurgeCmd(cfg),
 		newDurableQueuesCmd(cfg),
+		newDurableStatsCmd(cfg),
+		newDurableDeleteCmd(cfg),
 		newDurableGetCmd(cfg),
 		newDurableDumpCmd(cfg),
 	)

--- a/cmd/workerctl/durable_delete.go
+++ b/cmd/workerctl/durable_delete.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hyp3rd/ewrap"
+	"github.com/redis/rueidis"
+	"github.com/spf13/cobra"
+)
+
+const deleteScript = `
+local dead = KEYS[1]
+local ready = KEYS[2]
+local processing = KEYS[3]
+local taskKey = KEYS[4]
+local now = tonumber(ARGV[1])
+local id = ARGV[2]
+local deleteHash = ARGV[3]
+
+redis.call("ZREM", ready, id)
+redis.call("ZREM", processing, id)
+redis.call("LREM", dead, 0, id)
+redis.call("HSET", taskKey, "updated_at_ms", now)
+
+if deleteHash == "1" then
+  redis.call("DEL", taskKey)
+end
+
+return 1
+`
+
+type deleteOptions struct {
+	id           string
+	queue        string
+	deleteHash   bool
+	apply        bool
+	defaultQueue string
+}
+
+func newDurableDeleteCmd(cfg *redisConfig) *cobra.Command {
+	opts := &deleteOptions{
+		defaultQueue: defaultQueueName,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete a durable task from queues and optionally its hash",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runDurableDelete(cfg, *opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&opts.id, "id", "", "task ID to delete")
+	flags.StringVar(&opts.queue, "queue", "", "queue name override")
+	flags.BoolVar(&opts.deleteHash, "delete-hash", false, "delete the task hash after removal")
+	flags.BoolVar(&opts.apply, "apply", false, "apply delete (default is dry-run)")
+	flags.StringVar(&opts.defaultQueue, "default-queue", opts.defaultQueue, "fallback queue when task queue is missing")
+
+	return cmd
+}
+
+func runDurableDelete(cfg *redisConfig, opts deleteOptions) error {
+	if strings.TrimSpace(opts.id) == "" {
+		return ewrap.New("--id is required")
+	}
+
+	if !opts.apply {
+		fmt.Fprintf(os.Stdout, "dry-run: use --apply to delete task %s\n", opts.id)
+
+		return nil
+	}
+
+	client, err := cfg.client()
+	if err != nil {
+		return ewrap.Wrap(err, "redis client")
+	}
+	defer client.Close()
+
+	ctx, cancel := cfg.context()
+	defer cancel()
+
+	prefix := keyPrefix(cfg.prefix)
+
+	queueName, err := resolveTaskQueue(ctx, client, prefix, opts.id, opts.queue, opts.defaultQueue)
+	if err != nil {
+		return err
+	}
+
+	readyKey := queueKey(prefix, "ready", queueName)
+	processingKey := queueKey(prefix, "processing", queueName)
+	deadKey := prefix + ":dead"
+	taskKey := prefix + ":task:" + opts.id
+
+	resp := rueidis.NewLuaScript(deleteScript).Exec(
+		ctx,
+		client,
+		[]string{deadKey, readyKey, processingKey, taskKey},
+		[]string{
+			strconv.FormatInt(timeNowMillis(), 10),
+			opts.id,
+			boolToFlag(opts.deleteHash),
+		},
+	)
+
+	err = resp.Error()
+	if err != nil {
+		return ewrap.Wrap(err, "delete task")
+	}
+
+	fmt.Fprintf(os.Stdout, "deleted task %s\n", opts.id)
+
+	return nil
+}
+
+func timeNowMillis() int64 {
+	return time.Now().UnixMilli()
+}
+
+func boolToFlag(value bool) string {
+	if value {
+		return "1"
+	}
+
+	return "0"
+}
+
+func resolveTaskQueue(
+	ctx context.Context,
+	client rueidis.Client,
+	prefix string,
+	id string,
+	override string,
+	fallback string,
+) (string, error) {
+	override = strings.TrimSpace(override)
+	if override != "" {
+		return override, nil
+	}
+
+	taskKey := prefix + ":task:" + id
+	resp := client.Do(ctx, client.B().Hget().Key(taskKey).Field("queue").Build())
+
+	queue, err := resp.ToString()
+	if err != nil {
+		if rueidis.IsRedisNil(err) {
+			if fallback == "" {
+				return defaultQueueName, nil
+			}
+
+			return fallback, nil
+		}
+
+		return "", fmt.Errorf("read task queue: %w", err)
+	}
+
+	queue = strings.TrimSpace(queue)
+	if queue == "" {
+		if fallback == "" {
+			return defaultQueueName, nil
+		}
+
+		return fallback, nil
+	}
+
+	return queue, nil
+}

--- a/cmd/workerctl/durable_dump.go
+++ b/cmd/workerctl/durable_dump.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"strconv"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/hyp3rd/ewrap"
 	"github.com/redis/rueidis"
 	"github.com/spf13/cobra"

--- a/cmd/workerctl/durable_get.go
+++ b/cmd/workerctl/durable_get.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 
+	"github.com/goccy/go-json"
 	"github.com/hyp3rd/ewrap"
 	"github.com/redis/rueidis"
 	"github.com/spf13/cobra"

--- a/cmd/workerctl/durable_requeue.go
+++ b/cmd/workerctl/durable_requeue.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/hyp3rd/ewrap"
+	"github.com/spf13/cobra"
+)
+
+type requeueOptions struct {
+	queue        string
+	processing   bool
+	limit        int
+	delay        time.Duration
+	apply        bool
+	defaultQueue string
+}
+
+func newDurableRequeueCmd(cfg *redisConfig) *cobra.Command {
+	opts := &requeueOptions{
+		defaultQueue: defaultQueueName,
+		limit:        defaultRetryLimit,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "requeue",
+		Short: "Requeue tasks from ready or processing queues",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runDurableRequeue(cfg, *opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&opts.queue, "queue", "", "queue name to requeue from")
+	flags.BoolVar(&opts.processing, "processing", false, "requeue from processing instead of ready")
+	flags.IntVar(&opts.limit, "limit", opts.limit, "max tasks to requeue (0 = all)")
+	flags.DurationVar(&opts.delay, "delay", 0, "delay before requeue (e.g. 5s)")
+	flags.BoolVar(&opts.apply, "apply", false, "apply requeue (default is dry-run)")
+	flags.StringVar(&opts.defaultQueue, "default-queue", opts.defaultQueue, "fallback queue when task queue is missing")
+
+	return cmd
+}
+
+func runDurableRequeue(cfg *redisConfig, opts requeueOptions) error {
+	queue := strings.TrimSpace(opts.queue)
+	if queue == "" {
+		return ewrap.New("--queue is required")
+	}
+
+	source := retrySourceReady
+	if opts.processing {
+		source = retrySourceProc
+	}
+
+	retryOpts := retryOptions{
+		source:       source,
+		fromQueue:    queue,
+		limit:        opts.limit,
+		delay:        opts.delay,
+		apply:        opts.apply,
+		defaultQueue: opts.defaultQueue,
+	}
+
+	if !opts.apply {
+		fmt.Fprintf(os.Stdout, "dry-run: use --apply to requeue from %s\n", source)
+
+		return nil
+	}
+
+	return runDurableRetry(cfg, retryOpts)
+}

--- a/cmd/workerctl/durable_stats.go
+++ b/cmd/workerctl/durable_stats.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"os"
+
+	"github.com/goccy/go-json"
+	"github.com/hyp3rd/ewrap"
+	"github.com/spf13/cobra"
+)
+
+type statsOptions struct {
+	jsonOutput bool
+}
+
+type statsSnapshot struct {
+	Queues          []queueCounts `json:"queues"`
+	TotalReady      int64         `json:"total_ready"`
+	TotalProcessing int64         `json:"total_processing"`
+	Dead            int64         `json:"dead"`
+}
+
+func newDurableStatsCmd(cfg *redisConfig) *cobra.Command {
+	opts := &statsOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "stats",
+		Short: "Show durable queue stats",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runDurableStats(cfg, *opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.BoolVar(&opts.jsonOutput, "json", false, "output JSON")
+
+	return cmd
+}
+
+func runDurableStats(cfg *redisConfig, opts statsOptions) error {
+	client, err := cfg.client()
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	ctx, cancel := cfg.context()
+	defer cancel()
+
+	prefix := keyPrefix(cfg.prefix)
+
+	deadCount, err := fetchDeadCount(ctx, client, prefix)
+	if err != nil {
+		return err
+	}
+
+	queues, err := resolveQueues(ctx, client, prefix+":queues", "")
+	if err != nil {
+		return err
+	}
+
+	counts, totals, err := fetchQueueCounts(ctx, client, prefix, queues)
+	if err != nil {
+		return err
+	}
+
+	if opts.jsonOutput {
+		payload := statsSnapshot{
+			Queues:          counts,
+			TotalReady:      totals.ready,
+			TotalProcessing: totals.processing,
+			Dead:            deadCount,
+		}
+
+		err := json.NewEncoder(os.Stdout).Encode(payload)
+		if err != nil {
+			return ewrap.Wrap(err, "encode json")
+		}
+	}
+
+	printQueueCounts(counts, totals, deadCount)
+
+	return nil
+}

--- a/cspell.json
+++ b/cspell.json
@@ -67,6 +67,7 @@
     "gitversion",
     "GOARCH",
     "gocache",
+    "goccy",
     "gocognit",
     "gofiber",
     "GOFILES",

--- a/durable_redis.go
+++ b/durable_redis.go
@@ -2,7 +2,6 @@ package worker
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"slices"
 	"sort"
@@ -12,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/google/uuid"
 	"github.com/hyp3rd/ewrap"
 	"github.com/redis/rueidis"

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/hyp3rd/go-worker
 go 1.25.6
 
 require (
+	github.com/goccy/go-json v0.10.5
 	github.com/google/uuid v1.6.0
 	github.com/hyp3rd/ewrap v1.3.7
 	github.com/redis/rueidis v1.0.71
@@ -18,7 +19,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect


### PR DESCRIPTION
- Add `workerctl durable requeue` shortcut to requeue a queue directly
- Add `workerctl durable delete` to delete a task (optionally also delete its hash)
  - Uses an embedded Lua script for the Redis-side delete behavior
- Add `workerctl durable stats` with optional JSON output
- Register the new durable subcommands in `cmd/workerctl/durable.go`
- Switch JSON encoding to `github.com/goccy/go-json` and add dependency in `go.mod`
- Update `README.md` with usage docs for requeue/delete/stats