### PR TITLE
feat(workerctl/durable): add paused status command and improve dump/delete tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ Pause/resume durable dequeue:
 ```bash
 ./workerctl durable pause --apply
 ./workerctl durable resume --apply
+./workerctl durable paused
 ```
 
 Purge queues (use with care):

--- a/cmd/workerctl/durable.go
+++ b/cmd/workerctl/durable.go
@@ -12,6 +12,7 @@ func newDurableCmd(cfg *redisConfig) *cobra.Command {
 		newDurableInspectCmd(cfg),
 		newDurablePauseCmd(cfg),
 		newDurableResumeCmd(cfg),
+		newDurablePausedCmd(cfg),
 		newDurableDLQCmd(cfg),
 		newDurableRetryCmd(cfg),
 		newDurableRequeueCmd(cfg),

--- a/cmd/workerctl/durable_paused.go
+++ b/cmd/workerctl/durable_paused.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/hyp3rd/ewrap"
+	"github.com/redis/rueidis"
+	"github.com/spf13/cobra"
+)
+
+func newDurablePausedCmd(cfg *redisConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "paused",
+		Short: "Show durable pause status",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runDurablePaused(cfg)
+		},
+	}
+
+	return cmd
+}
+
+func runDurablePaused(cfg *redisConfig) error {
+	client, err := cfg.client()
+	if err != nil {
+		return ewrap.Wrap(err, "redis client")
+	}
+	defer client.Close()
+
+	ctx, cancel := cfg.context()
+	defer cancel()
+
+	key := pausedKey(keyPrefix(cfg.prefix))
+	resp := client.Do(ctx, client.B().Get().Key(key).Build())
+
+	value, err := resp.ToString()
+	if err != nil {
+		if rueidis.IsRedisNil(err) {
+			fmt.Fprintln(os.Stdout, "paused=false")
+
+			return nil
+		}
+
+		return ewrap.Wrap(err, "read pause state")
+	}
+
+	if value == "1" {
+		fmt.Fprintln(os.Stdout, "paused=true")
+
+		return nil
+	}
+
+	fmt.Fprintln(os.Stdout, "paused=false")
+
+	return nil
+}


### PR DESCRIPTION
- add `durable paused` subcommand to report pause state from Redis
- extend `durable delete` to support multiple --id values or deletion by --source with --limit/--from-queue, with clearer validation + dry-run output
- add handler/retry/age filters to `durable dump` and refactor dumping via a dumpContext
- document the new `./workerctl durable paused` example in README