### PR TITLE
feat(admin): add audit events, export, artifacts, guardrails, and observability

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -175,7 +175,7 @@ linters:
           arguments: [140]
 
         - name: max-public-structs
-          arguments: [20]
+          arguments: [25]
 
         - name: var-naming
           disabled: true

--- a/PRD-admin-service.md
+++ b/PRD-admin-service.md
@@ -120,6 +120,8 @@ Service: `worker.v1.AdminService`
 - `GET /admin/v1/jobs/events?name=job_name&limit=25`
 - `GET /admin/v1/dlq?limit=100&offset=0&queue=default&handler=send_email&query=oops`
 - `GET /admin/v1/dlq/{id}`
+- `GET /admin/v1/audit?limit=100&action=queue.pause&target=default`
+- `GET /admin/v1/audit/export?format=jsonl|json|csv&limit=1000&action=...&target=...`
 - `POST /admin/v1/pause`
 - `POST /admin/v1/resume`
 - `POST /admin/v1/dlq/replay` (body: `{ "limit": 100 }`)
@@ -141,6 +143,8 @@ Service: `worker.v1.AdminService`
 - `WORKER_ADMIN_GRPC_TARGET` (optional; when set, the gateway dials this address instead of starting a local AdminService)
 - `WORKER_ADMIN_HTTP_ADDR` (default `127.0.0.1:8081`)
 - `WORKER_ADMIN_TLS_CERT`, `WORKER_ADMIN_TLS_KEY`, `WORKER_ADMIN_TLS_CA`
+- `WORKER_ADMIN_AUDIT_EVENT_LIMIT` (max audit events retained by service/backend list operations)
+- `WORKER_ADMIN_AUDIT_EXPORT_LIMIT_MAX` (gateway cap for export query `limit`)
 - `WORKER_ADMIN_DEFAULT_QUEUE`, `WORKER_ADMIN_QUEUE_WEIGHTS` (backend defaults)
 
 Worker service cron presets (when using the bundled worker-service):
@@ -171,22 +175,70 @@ Worker service job runner (containerized):
 - Log errors and action outcomes at INFO/WARN levels.
 - Add counters for admin actions (pause/resume/replay).
 
-## Implementation Status (February 9, 2026)
+## Implementation Status (February 10, 2026)
 
-- **Overview/Queues/Queue detail**: Implemented (gRPC + gateway + UI).
-- **Queue actions**: Implemented (set/reset weight + pause/resume via gRPC + gateway + UI).
-- **DLQ pagination + filters**: Implemented in API; UI supports search + queue/handler filters with paging.
-- **DLQ replay**: Implemented (bulk replay by limit + replay by ID/selection).
-- **DLQ detail**: Implemented (gRPC + gateway + UI detail panel).
-- **Schedules**: Implemented from in-memory cron registry; UI shows next/last run. Durable backends report schedules via TaskManager.
-- **Schedule factories**: Implemented (gRPC + gateway).
-- **Health/version**: Implemented (gateway + UI).
-- **Observability counters**: Implemented (pause/resume/replay action counts in overview).
-- **Schedule management endpoints**: Implemented (create/delete/pause/run + pause-all via gRPC + gateway + UI).
-- **Events stream**: Implemented (gateway SSE + UI schedule + job event logs via `/api/events`).
-- **Jobs (containerized runner)**: Implemented (API + worker-service + UI + event feed).
-- **Job sources**: Implemented (Git tag, HTTPS tarball, local tarball path with allowlist + SHA256 validation).
-- **Job event persistence**: Implemented (file-backed store via `WORKER_JOB_EVENT_DIR`).
+### Service (gRPC + gateway)
+
+- **Implemented**
+        - Overview, health, queues (list/get/weight/pause), schedules (list/factories/create/delete/pause/run/pause-all), jobs (list/get/upsert/delete/run), DLQ (list/detail/replay/replay-by-id), pause/resume dequeue, SSE events.
+        - Containerized job runner supports `git_tag`, `tarball_url`, `tarball_path`, allowlists, SHA256 validation, output truncation.
+        - Job event persistence is available via file-backed store (`WORKER_JOB_EVENT_DIR`).
+        - Admin observability collector is available with gateway middleware and gRPC unary interceptors; snapshot endpoint: `GET /admin/v1/metrics` (HTTP/gRPC latency, error counts, and job-runner outcome counters).
+        - Guardrails are configurable via env for replay caps, schedule run caps, and optional approval token checks (`WORKER_ADMIN_REPLAY_LIMIT_MAX`, `WORKER_ADMIN_REPLAY_IDS_MAX`, `WORKER_ADMIN_SCHEDULE_RUN_MAX`, `WORKER_ADMIN_SCHEDULE_RUN_WINDOW`, `WORKER_ADMIN_REQUIRE_APPROVAL`, `WORKER_ADMIN_APPROVAL_TOKEN`).
+        - Artifact API parity: gateway now exposes job artifact metadata and download endpoints (`GET /admin/v1/jobs/{name}/artifact/meta`, `GET /admin/v1/jobs/{name}/artifact`) so UI no longer needs direct filesystem access for tarball-path jobs.
+        - Audit export is available at `GET /admin/v1/audit/export` (`jsonl`, `json`, `csv`) with action/target filtering and bounded limits.
+        - Audit retention is configurable via `WORKER_ADMIN_AUDIT_EVENT_LIMIT`, and gateway export limits are capped by `WORKER_ADMIN_AUDIT_EXPORT_LIMIT_MAX`.
+        - Gateway artifact handling now runs behind an internal artifact-store abstraction (filesystem implementation), reducing direct coupling in handlers.
+- **Partial / gaps**
+        - Event stream now supports `Last-Event-ID` with bounded in-memory replay; replay does not survive gateway restarts.
+        - Metrics are in-memory snapshots; no OpenTelemetry/Prometheus export yet for cluster-wide scraping and long-term retention.
+        - Central audit log supports count-based retention + export; time-window retention policy is still pending.
+        - No RBAC/authorization model beyond mTLS + perimeter controls.
+        - Artifact download for `tarball_path` depends on gateway runtime mounts/config (`WORKER_ADMIN_JOB_TARBALL_DIR`) when worker and gateway are split.
+
+### Admin UI
+
+- **Implemented**
+        - Operational pages for Overview, Queues, Schedules, DLQ, Jobs, Settings, and Docs.
+        - Action flows for queue weight/pause, schedule management, DLQ replay, job creation/run/edit/delete.
+        - Run-level page for jobs and event panes for schedules/jobs.
+        - SSE + polling fallback for live updates.
+- **Partial / gaps**
+        - Overview analytics are snapshot-focused; no built-in trend charts across day/week/month windows for all domains.
+        - Event UX is list-based; no cursor-driven timeline, grouping, or cross-resource correlation view.
+        - Some high-value admin workflows are still split across pages (no global command palette / cross-page quick actions).
+        - Artifact handling is source-aware but still operationally coupled to environment mounts for local tarballs.
+
+## Gap Analysis (Production Focus)
+
+### Must-have (service)
+
+1. **Admin observability**: implemented as in-memory service metrics + gateway endpoint; pending OTel/Prometheus export and durable retention.
+1. **Policy enforcement**: implemented for DLQ replay caps, schedule run caps, and optional approval token checks in admin mutations.
+1. **Artifact API parity**: implemented in gateway with an artifact-store abstraction; remaining work is non-filesystem providers (S3/object store) and signed URL policies.
+1. **Audit retention/export**: implemented for count-based retention + export endpoints; remaining work is time-window retention policy and scheduled archival.
+
+### Must-have (admin UI)
+
+1. **Unified run visibility**: show queued/running/completed transitions consistently with per-run immutable detail pages.
+1. **Operational timelines**: add correlation view for queue/schedule/job/DLQ events (single timeline with filters).
+1. **Safety UX**: richer confirmation modals for risky actions with impact preview (counts, targets, scope).
+1. **Error diagnostics**: structured error panels for gateway/API failures (request ID, mapped cause, recovery hint).
+1. **State persistence**: persist user filters/sorts/page-size per section for operator continuity.
+
+### Nice-to-have (service)
+
+1. S3/object-store event backend (in addition to file store) with retention lifecycle controls.
+1. OpenAPI/JSON schema export for gateway endpoints.
+1. WebSocket transport as optional alternative to SSE.
+1. Multi-tenant authn/authz integration points (OIDC headers, signed tokens, policy hooks).
+
+### Nice-to-have (admin UI)
+
+1. Trend cards and small charts for throughput/failure/replay over configurable windows.
+1. Bulk action workbench for queues/schedules/jobs with dry-run mode.
+1. Advanced docs integration: contextual “why this failed” links from runtime errors to docs sections.
+1. Exportable reports (CSV/JSON) for run history and DLQ operations.
 
 ## Milestones
 

--- a/PRD.md
+++ b/PRD.md
@@ -150,12 +150,13 @@ Status updated: **_February 5, 2026_**
 
 ### Admin Service & Admin UI
 
-- **Admin Service (gRPC + HTTP gateway)**: Done (mTLS required, request IDs, timeouts, consistent error envelope, queue detail, DLQ pagination/filters, schedules, health/version).
-- **Admin UI (Next.js + Tailwind)**: Done (overview/queues/DLQ/schedules, queue detail page, server-side DLQ paging/filters, runbook actions, session auth, audit banner, replay‑by‑ID selection).
+- **Admin Service (gRPC + HTTP gateway)**: Implemented with gaps (resumable SSE, central audit log, per-endpoint metrics, gateway artifact API parity).
+- **Admin UI (Next.js + Tailwind)**: Implemented with gaps (cross-resource timeline, trend analytics, richer operator workflows, stronger diagnostics UX).
 - **Docker/Compose**: Done (`Dockerfile` + `compose.admin.yaml` + cert generation script).
 - **Schedule management**: Done (create/delete/pause via gateway + UI).
 - **Admin action counters**: Done (pause/resume/replay counts exposed in overview).
-- **UI polish**: In progress (settings metadata panel added; continued UX refinements ongoing).
+- **UI polish**: In progress (actions, events, run detail, docs; deeper productization still in progress).
+- **Canonical admin status**: See `PRD-admin-service.md` for detailed service/UI gap matrix and priority backlog.
 
 ## Milestones
 
@@ -198,6 +199,6 @@ Status updated: **_February 5, 2026_**
 ### Roadmap (future milestones)
 
 1. **Durable backend**: add additional backends (Postgres) and stronger transactional enqueue semantics.
-1. **Operational tooling**: admin UI and admin service implemented; expand CLI release workflow and deep admin features (filters, export, advanced replay).
+1. **Operational tooling**: admin service/UI are implemented; close remaining productization gaps (resumable events, auditability, analytics, advanced workflows).
 1. **Scheduled jobs**: cron/delayed scheduling layer (cron now implemented; cron UX improvements TBD).
 1. **Multi‑node coordination**: optional distributed workers via backend (global rate limit/leader lock implemented; quorum/leader election improvements TBD).

--- a/admin-ui/README.md
+++ b/admin-ui/README.md
@@ -28,9 +28,13 @@ UI env vars:
 - `WORKER_ADMIN_API_URL` (e.g. `https://127.0.0.1:8081`)
 - `WORKER_ADMIN_MTLS_CERT`, `WORKER_ADMIN_MTLS_KEY`, `WORKER_ADMIN_MTLS_CA`
 - `WORKER_ADMIN_PASSWORD` (required)
-- `WORKER_ADMIN_JOB_TARBALL_DIR` (required for local tarball downloads)
 - `WORKER_ADMIN_ALLOW_MOCK=false`
 - `NEXT_PUBLIC_WORKER_ADMIN_ORIGIN` (optional override for SSR fetch)
+
+Gateway env vars (set on `worker-admin`):
+
+- `WORKER_ADMIN_JOB_TARBALL_DIR` (optional; enables local tarball download proxy)
+- `WORKER_ADMIN_AUDIT_EXPORT_LIMIT_MAX` (optional cap for `GET /admin/v1/audit/export`)
 
 Worker-service job runner (for Jobs + events):
 
@@ -43,6 +47,18 @@ Worker-service job runner (for Jobs + events):
 - `WORKER_JOB_EVENT_DIR` (required to persist job events)
 - `WORKER_JOB_EVENT_MAX_ENTRIES` (per key; default 10000)
 - `WORKER_JOB_EVENT_CACHE_TTL` (default 10s)
+
+## Audit export
+
+The Overview runbook now includes an `Export audit` control that downloads
+gateway audit records with optional filters.
+
+- API route: `GET /api/audit/export`
+- Supported query params:
+      - `format`: `jsonl` (default), `json`, `csv`
+      - `limit`: max records (gateway-enforced cap)
+      - `action`: optional action filter
+      - `target`: optional target filter
 
 ## Crash-test preset
 

--- a/admin-ui/src/app/(app)/page.tsx
+++ b/admin-ui/src/app/(app)/page.tsx
@@ -7,6 +7,7 @@ import { JobOverview } from "@/components/job-overview";
 import Link from "next/link";
 import {
   getAdminActionCounters,
+  getAuditEvents,
   getCoordinationStatus,
   getJobEvents,
   getJobSchedules,
@@ -18,13 +19,14 @@ import { formatLatency, formatNumber } from "@/lib/format";
 export const dynamic = "force-dynamic";
 
 export default async function Home() {
-  const [stats, queues, jobs, coordination, actions, jobEvents] = await Promise.all([
+  const [stats, queues, jobs, coordination, actions, jobEvents, auditEvents] = await Promise.all([
     getOverviewStats(),
     getQueueSummaries(),
     getJobSchedules(),
     getCoordinationStatus(),
     getAdminActionCounters(),
     getJobEvents({ limit: 200 }),
+    getAuditEvents({ limit: 50 }),
   ]);
 
   return (
@@ -99,7 +101,7 @@ export default async function Home() {
             title="Runbook"
             description="High‑confidence actions for production."
           />
-          <RunbookActions paused={coordination.paused} />
+          <RunbookActions paused={coordination.paused} initialAuditEvents={auditEvents} />
           <div className="mt-6 rounded-2xl border border-soft bg-[var(--card)] p-4">
             <p className="text-xs uppercase tracking-[0.2em] text-muted">
               Action counters

--- a/admin-ui/src/app/api/audit/export/route.ts
+++ b/admin-ui/src/app/api/audit/export/route.ts
@@ -1,0 +1,87 @@
+import { Readable } from "stream";
+import { NextResponse, type NextRequest } from "next/server";
+import { gatewayRawRequest } from "@/lib/gateway";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const defaultLimit = 500;
+const maxLimit = 5000;
+
+const parseLimit = (raw: string | null) => {
+  if (!raw) {
+    return defaultLimit;
+  }
+
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value <= 0) {
+    return defaultLimit;
+  }
+
+  return Math.min(Math.floor(value), maxLimit);
+};
+
+const parseFormat = (raw: string | null) => {
+  const normalized = (raw ?? "").trim().toLowerCase();
+  if (normalized === "json" || normalized === "csv") {
+    return normalized;
+  }
+
+  return "jsonl";
+};
+
+export async function GET(request: NextRequest) {
+  try {
+    const url = new URL(request.url);
+    const action = (url.searchParams.get("action") ?? "").trim();
+    const target = (url.searchParams.get("target") ?? "").trim();
+    const limit = parseLimit(url.searchParams.get("limit"));
+    const format = parseFormat(url.searchParams.get("format"));
+
+    const query = new URLSearchParams();
+    query.set("format", format);
+    query.set("limit", String(limit));
+    if (action) {
+      query.set("action", action);
+    }
+    if (target) {
+      query.set("target", target);
+    }
+
+    const { stream, headers } = await gatewayRawRequest({
+      method: "GET",
+      path: `/admin/v1/audit/export?${query.toString()}`,
+    });
+
+    const webStream = Readable.toWeb(
+      stream as unknown as Readable
+    ) as ReadableStream<Uint8Array>;
+
+    const contentType = getHeaderValue(headers["content-type"]) ?? "application/x-ndjson";
+    const disposition =
+      getHeaderValue(headers["content-disposition"]) ??
+      `attachment; filename="admin-audit.${format}"`;
+
+    return new NextResponse(webStream, {
+      status: 200,
+      headers: {
+        "Content-Type": contentType,
+        "Content-Disposition": disposition,
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: (error as Error).message ?? "audit_export_failed" },
+      { status: 502 }
+    );
+  }
+}
+
+const getHeaderValue = (value: string | string[] | undefined) => {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return value;
+};

--- a/admin-ui/src/app/api/audit/route.ts
+++ b/admin-ui/src/app/api/audit/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { gatewayRequest } from "@/lib/gateway";
+import type { AdminAuditEvent } from "@/lib/types";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const parseLimit = (raw: string | null) => {
+  if (!raw) {
+    return 100;
+  }
+
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value <= 0) {
+    return 100;
+  }
+
+  return Math.min(Math.floor(value), 1000);
+};
+
+export async function GET(request: Request) {
+  try {
+    const url = new URL(request.url);
+    const action = (url.searchParams.get("action") ?? "").trim();
+    const target = (url.searchParams.get("target") ?? "").trim();
+    const limit = parseLimit(url.searchParams.get("limit"));
+
+    const query = new URLSearchParams();
+    if (action) {
+      query.set("action", action);
+    }
+    if (target) {
+      query.set("target", target);
+    }
+    query.set("limit", String(limit));
+
+    const path = `/admin/v1/audit?${query.toString()}`;
+    const payload = await gatewayRequest<{ events: AdminAuditEvent[] }>({
+      method: "GET",
+      path,
+    });
+
+    return NextResponse.json(payload);
+  } catch (error) {
+    return NextResponse.json(
+      { error: (error as Error).message ?? "admin_gateway_unavailable" },
+      { status: 502 }
+    );
+  }
+}

--- a/admin-ui/src/app/api/events/route.ts
+++ b/admin-ui/src/app/api/events/route.ts
@@ -4,9 +4,11 @@ import { NextResponse } from "next/server";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
-    const { stream } = await gatewayStream("/admin/v1/events");
+    const { stream } = await gatewayStream("/admin/v1/events", {
+      lastEventId: request.headers.get("last-event-id") ?? "",
+    });
 
     const body = new ReadableStream<Uint8Array>({
       start(controller) {

--- a/admin-ui/src/lib/api.ts
+++ b/admin-ui/src/lib/api.ts
@@ -6,6 +6,7 @@ import type {
   DlqEntry,
   HealthInfo,
   JobEvent,
+  AdminAuditEvent,
   JobSchedule,
   OverviewStats,
   QueueDetail,
@@ -125,6 +126,26 @@ export async function fetchJobEvents(params?: {
   }
   const suffix = search.toString();
   const path = suffix ? `/api/jobs/events?${suffix}` : "/api/jobs/events";
+  return fetchJson(path);
+}
+
+export async function fetchAuditEvents(params?: {
+  action?: string;
+  target?: string;
+  limit?: number;
+}): Promise<{ events: AdminAuditEvent[] }> {
+  const search = new URLSearchParams();
+  if (params?.action) {
+    search.set("action", params.action);
+  }
+  if (params?.target) {
+    search.set("target", params.target);
+  }
+  if (params?.limit) {
+    search.set("limit", String(params.limit));
+  }
+  const suffix = search.toString();
+  const path = suffix ? `/api/audit?${suffix}` : "/api/audit";
   return fetchJson(path);
 }
 

--- a/admin-ui/src/lib/data.ts
+++ b/admin-ui/src/lib/data.ts
@@ -10,6 +10,7 @@ import {
   fetchSchedules,
   fetchJobs,
   fetchJobEvents,
+  fetchAuditEvents,
 } from "@/lib/api";
 import {
   coordinationStatus,
@@ -227,5 +228,20 @@ export const getDlqEntries = cache(async (params?: {
     const detail =
       error instanceof Error ? error.message : "unknown error";
     throw new Error(`Failed to load DLQ entries: ${detail}`);
+  }
+});
+
+export const getAuditEvents = cache(async (params?: {
+  action?: string;
+  target?: string;
+  limit?: number;
+}) => {
+  try {
+    const { events } = await fetchAuditEvents(params);
+    return events;
+  } catch (error) {
+    const detail =
+      error instanceof Error ? error.message : "unknown error";
+    throw new Error(`Failed to load admin audit events: ${detail}`);
   }
 });

--- a/admin-ui/src/lib/gateway.ts
+++ b/admin-ui/src/lib/gateway.ts
@@ -9,6 +9,12 @@ type GatewayRequest = {
   body?: unknown;
 };
 
+type GatewayRawRequest = {
+  method?: "GET" | "POST" | "DELETE";
+  path: string;
+  headers?: Record<string, string>;
+};
+
 type GatewayConfig = {
   baseUrl: string;
   certPath: string;
@@ -187,7 +193,10 @@ const parseGatewayError = (
   }
 };
 
-export const gatewayStream = async (path: string) => {
+export const gatewayStream = async (
+  path: string,
+  opts?: { lastEventId?: string }
+) => {
   const config = loadConfig();
   const url = new URL(path, config.baseUrl);
   const isTLS = url.protocol === "https:";
@@ -196,9 +205,72 @@ export const gatewayStream = async (path: string) => {
     Accept: "text/event-stream",
     "X-Request-Id": crypto.randomUUID(),
   };
+  const lastEventID = opts?.lastEventId?.trim();
+  if (lastEventID) {
+    headers["Last-Event-ID"] = lastEventID;
+  }
 
   const requestOptions: https.RequestOptions = {
     method: "GET",
+    headers,
+  };
+
+  if (isTLS) {
+    Object.assign(requestOptions, loadTLS(config));
+  }
+
+  const client = isTLS ? https : http;
+
+  return new Promise<{
+    statusCode: number;
+    headers: http.IncomingHttpHeaders;
+    stream: NodeJS.ReadableStream;
+  }>((resolve, reject) => {
+    const req = client.request(url, requestOptions, (res) => {
+      const statusCode = res.statusCode ?? 0;
+      if (statusCode >= 400) {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk) => chunks.push(chunk));
+        res.on("end", () => {
+          const raw = Buffer.concat(chunks).toString("utf8");
+          const parsed = parseGatewayError(raw);
+          const message = parsed
+            ? `${parsed.message} (${parsed.code})`
+            : raw || `gateway error ${statusCode}`;
+          reject(new Error(message));
+        });
+        return;
+      }
+
+      resolve({
+        statusCode,
+        headers: res.headers,
+        stream: res,
+      });
+    });
+
+    req.on("error", (err) => reject(err));
+    req.end();
+  });
+};
+
+export const gatewayRawRequest = async ({
+  method = "GET",
+  path,
+  headers: extraHeaders,
+}: GatewayRawRequest) => {
+  const config = loadConfig();
+  const url = new URL(path, config.baseUrl);
+  const isTLS = url.protocol === "https:";
+
+  const headers: Record<string, string> = {
+    Accept: "*/*",
+    "X-Request-Id": crypto.randomUUID(),
+    ...extraHeaders,
+  };
+
+  const requestOptions: https.RequestOptions = {
+    method,
     headers,
   };
 

--- a/admin-ui/src/lib/types.ts
+++ b/admin-ui/src/lib/types.ts
@@ -81,6 +81,18 @@ export type JobEvent = {
   metadata?: Record<string, string>;
 };
 
+export type AdminAuditEvent = {
+  atMs: number;
+  actor: string;
+  requestId: string;
+  action: string;
+  target: string;
+  status: string;
+  payloadHash?: string;
+  detail: string;
+  metadata?: Record<string, string>;
+};
+
 export type OverviewStats = {
   activeWorkers: number;
   queuedTasks: number;

--- a/admin_artifact_store.go
+++ b/admin_artifact_store.go
@@ -1,0 +1,111 @@
+package worker
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/hyp3rd/ewrap"
+	sectools "github.com/hyp3rd/sectools/pkg/io"
+
+	workerpb "github.com/hyp3rd/go-worker/pkg/worker/v1"
+)
+
+type adminArtifactStore interface {
+	Resolve(job *workerpb.Job) (adminJobArtifactJSON, error)
+}
+
+type localAdminArtifactStore struct {
+	tarballDir string
+}
+
+func newAdminArtifactStore(jobTarballDir string) adminArtifactStore {
+	return localAdminArtifactStore{tarballDir: strings.TrimSpace(jobTarballDir)}
+}
+
+func (s localAdminArtifactStore) Resolve(job *workerpb.Job) (adminJobArtifactJSON, error) {
+	if job == nil || job.GetSpec() == nil {
+		return adminJobArtifactJSON{}, ErrAdminJobNotFound
+	}
+
+	spec := job.GetSpec()
+	artifact := adminJobArtifactJSON{
+		Name:   spec.GetName(),
+		Source: NormalizeJobSource(spec.GetSource()),
+		SHA256: strings.TrimSpace(spec.GetTarballSha256()),
+	}
+
+	switch artifact.Source {
+	case JobSourceTarballURL:
+		target := strings.TrimSpace(spec.GetTarballUrl())
+		if target == "" {
+			return adminJobArtifactJSON{}, ErrAdminJobTarballURLRequired
+		}
+
+		artifact.Downloadable = true
+		artifact.RedirectURL = target
+		artifact.Filename = filepath.Base(target)
+
+		return artifact, nil
+	case JobSourceTarballPath:
+		filePath, reader, err := s.resolveLocalArtifact(strings.TrimSpace(spec.GetTarballPath()))
+		if err != nil {
+			return adminJobArtifactJSON{}, err
+		}
+
+		file, err := reader.OpenFile(filePath)
+		if err != nil {
+			return adminJobArtifactJSON{}, ewrap.Wrap(err, "open artifact file")
+		}
+
+		stat, err := file.Stat()
+		closeErr := file.Close()
+
+		if err != nil {
+			return adminJobArtifactJSON{}, ewrap.Wrap(err, "stat artifact file")
+		}
+
+		if closeErr != nil {
+			return adminJobArtifactJSON{}, ewrap.Wrap(closeErr, "close artifact file")
+		}
+
+		if !stat.Mode().IsRegular() {
+			return adminJobArtifactJSON{}, ewrap.New("artifact is not a regular file")
+		}
+
+		artifact.Downloadable = true
+		artifact.Filename = filepath.Base(filePath)
+		artifact.SizeBytes = stat.Size()
+		artifact.LocalPath = filePath
+		artifact.Reader = reader
+
+		return artifact, nil
+	default:
+		return adminJobArtifactJSON{}, ewrap.Wrapf(ErrAdminUnsupported, "source %q", artifact.Source)
+	}
+}
+
+func (s localAdminArtifactStore) resolveLocalArtifact(tarballPath string) (string, *sectools.Client, error) {
+	if s.tarballDir == "" {
+		return "", nil, ewrap.New("artifact downloads are disabled")
+	}
+
+	cleanPath, err := sanitizeJobPath(tarballPath)
+	if err != nil || cleanPath == "" {
+		return "", nil, ErrAdminJobTarballPathRequired
+	}
+
+	absBase, err := filepath.Abs(s.tarballDir)
+	if err != nil {
+		return "", nil, ewrap.Wrap(err, "resolve tarball root")
+	}
+
+	reader, err := sectools.NewWithOptions(
+		sectools.WithAllowAbsolute(true),
+		sectools.WithAllowedRoots(absBase),
+	)
+	if err != nil {
+		return "", nil, ewrap.Wrap(err, "init artifact reader")
+	}
+
+	return filepath.Join(absBase, cleanPath), reader, nil
+}

--- a/admin_audit.go
+++ b/admin_audit.go
@@ -1,0 +1,159 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+)
+
+const (
+	defaultAdminAuditEventLimit = 500
+	adminAuditPersistTimeout    = 2 * time.Second
+)
+
+// AdminRecordAuditEvent persists an admin mutation audit record.
+func (tm *TaskManager) AdminRecordAuditEvent(ctx context.Context, event AdminAuditEvent, _ int) error {
+	if tm == nil {
+		return ErrAdminBackendUnavailable
+	}
+
+	if ctx == nil {
+		return ErrInvalidTaskContext
+	}
+
+	tm.recordAdminAuditEvent(ctx, event)
+
+	return nil
+}
+
+// AdminAuditEvents returns recent admin mutation audit records.
+func (tm *TaskManager) AdminAuditEvents(
+	ctx context.Context,
+	filter AdminAuditEventFilter,
+) (AdminAuditEventPage, error) {
+	if tm == nil {
+		return AdminAuditEventPage{}, ErrAdminBackendUnavailable
+	}
+
+	if ctx == nil {
+		return AdminAuditEventPage{}, ErrInvalidTaskContext
+	}
+
+	page, ok, err := tm.auditEventsFromBackend(ctx, filter)
+	if err != nil {
+		return AdminAuditEventPage{}, err
+	}
+
+	if ok {
+		return page, nil
+	}
+
+	return tm.auditEventsFromMemory(filter), nil
+}
+
+func (tm *TaskManager) recordAdminAuditEvent(ctx context.Context, event AdminAuditEvent) {
+	if tm == nil {
+		return
+	}
+
+	if event.At.IsZero() {
+		event.At = time.Now()
+	}
+
+	if strings.TrimSpace(event.Status) == "" {
+		event.Status = "ok"
+	}
+
+	tm.auditEventsMu.Lock()
+
+	tm.auditEvents = append(tm.auditEvents, event)
+	if tm.auditEventLimit > 0 && len(tm.auditEvents) > tm.auditEventLimit {
+		tm.auditEvents = tm.auditEvents[len(tm.auditEvents)-tm.auditEventLimit:]
+	}
+
+	tm.auditEventsMu.Unlock()
+
+	tm.persistAdminAuditEvent(ctx, event)
+}
+
+func (tm *TaskManager) persistAdminAuditEvent(ctx context.Context, event AdminAuditEvent) {
+	if tm == nil {
+		return
+	}
+
+	backend, err := tm.adminBackend()
+	if err != nil || backend == nil {
+		return
+	}
+
+	if ctx == nil {
+		return
+	}
+
+	persistBaseCtx := context.WithoutCancel(ctx)
+
+	persistCtx, cancel := context.WithTimeout(persistBaseCtx, adminAuditPersistTimeout)
+	defer cancel()
+
+	persistErr := backend.AdminRecordAuditEvent(persistCtx, event, tm.auditEventLimit)
+	if persistErr != nil {
+		return
+	}
+}
+
+func (tm *TaskManager) auditEventsFromBackend(
+	ctx context.Context,
+	filter AdminAuditEventFilter,
+) (AdminAuditEventPage, bool, error) {
+	backend, err := tm.adminBackend()
+	if err != nil {
+		if errors.Is(err, ErrAdminBackendUnavailable) {
+			return AdminAuditEventPage{}, false, nil
+		}
+
+		return AdminAuditEventPage{}, false, err
+	}
+
+	if backend == nil {
+		return AdminAuditEventPage{}, false, nil
+	}
+
+	page, fetchErr := backend.AdminAuditEvents(ctx, filter)
+	if fetchErr == nil {
+		return page, true, nil
+	}
+
+	if errors.Is(fetchErr, ErrAdminUnsupported) {
+		return AdminAuditEventPage{}, false, nil
+	}
+
+	return AdminAuditEventPage{}, false, fetchErr
+}
+
+func (tm *TaskManager) auditEventsFromMemory(filter AdminAuditEventFilter) AdminAuditEventPage {
+	tm.auditEventsMu.RLock()
+	events := make([]AdminAuditEvent, len(tm.auditEvents))
+	copy(events, tm.auditEvents)
+	tm.auditEventsMu.RUnlock()
+
+	limit := normalizeAdminEventLimit(filter.Limit, tm.auditEventLimit)
+	action := strings.TrimSpace(filter.Action)
+	target := strings.TrimSpace(filter.Target)
+
+	filtered := make([]AdminAuditEvent, 0, min(limit, len(events)))
+	for i := len(events) - 1; i >= 0 && len(filtered) < limit; i-- {
+		event := events[i]
+		if action != "" && event.Action != action {
+			continue
+		}
+
+		if target != "" && event.Target != target {
+			continue
+		}
+
+		filtered = append(filtered, event)
+	}
+
+	return AdminAuditEventPage{Events: filtered}
+}

--- a/admin_guardrails.go
+++ b/admin_guardrails.go
@@ -1,0 +1,191 @@
+package worker
+
+import (
+	"context"
+	"crypto/subtle"
+	"strings"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	adminApprovalMetaKey          = "x-admin-approval"
+	defaultAdminReplayLimitMax    = 1000
+	defaultAdminReplayIDsMax      = 1000
+	defaultAdminScheduleRunMax    = 30
+	defaultAdminScheduleRunWindow = time.Minute
+)
+
+// AdminGuardrails configures safety limits for high-impact admin operations.
+type AdminGuardrails struct {
+	ReplayLimitMax    int
+	ReplayIDsMax      int
+	ScheduleRunMax    int
+	ScheduleRunWindow time.Duration
+	RequireApproval   bool
+	ApprovalToken     string
+}
+
+type adminScheduleRunLimiter struct {
+	mu      sync.Mutex
+	limit   int
+	window  time.Duration
+	records map[string][]time.Time
+}
+
+func normalizeAdminGuardrails(cfg AdminGuardrails) AdminGuardrails {
+	if cfg.ReplayLimitMax <= 0 {
+		cfg.ReplayLimitMax = defaultAdminReplayLimitMax
+	}
+
+	if cfg.ReplayIDsMax <= 0 {
+		cfg.ReplayIDsMax = defaultAdminReplayIDsMax
+	}
+
+	if cfg.ScheduleRunMax <= 0 {
+		cfg.ScheduleRunMax = defaultAdminScheduleRunMax
+	}
+
+	if cfg.ScheduleRunWindow <= 0 {
+		cfg.ScheduleRunWindow = defaultAdminScheduleRunWindow
+	}
+
+	cfg.ApprovalToken = strings.TrimSpace(cfg.ApprovalToken)
+
+	return cfg
+}
+
+func newAdminScheduleRunLimiter(cfg AdminGuardrails) *adminScheduleRunLimiter {
+	if cfg.ScheduleRunMax <= 0 || cfg.ScheduleRunWindow <= 0 {
+		return nil
+	}
+
+	return &adminScheduleRunLimiter{
+		limit:   cfg.ScheduleRunMax,
+		window:  cfg.ScheduleRunWindow,
+		records: make(map[string][]time.Time),
+	}
+}
+
+func (limiter *adminScheduleRunLimiter) allow(name string, now time.Time) bool {
+	if limiter == nil {
+		return true
+	}
+
+	name = strings.TrimSpace(name)
+	if name == "" {
+		name = "*"
+	}
+
+	limiter.mu.Lock()
+	defer limiter.mu.Unlock()
+
+	windowStart := now.Add(-limiter.window)
+	current := limiter.records[name]
+
+	kept := make([]time.Time, 0, len(current)+1)
+	for _, ts := range current {
+		if ts.After(windowStart) {
+			kept = append(kept, ts)
+		}
+	}
+
+	if len(kept) >= limiter.limit {
+		limiter.records[name] = kept
+
+		return false
+	}
+
+	kept = append(kept, now)
+	limiter.records[name] = kept
+
+	return true
+}
+
+func (s *GRPCServer) enforceAdminApproval(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+
+	if !s.adminGuardrails.RequireApproval {
+		return nil
+	}
+
+	token := adminApprovalTokenFromContext(ctx)
+	if token == "" {
+		return ErrAdminApprovalRequired
+	}
+
+	expected := s.adminGuardrails.ApprovalToken
+	if expected == "" {
+		return nil
+	}
+
+	if subtle.ConstantTimeCompare([]byte(token), []byte(expected)) != 1 {
+		return ErrAdminApprovalInvalid
+	}
+
+	return nil
+}
+
+func (s *GRPCServer) enforceReplayLimit(limit int) error {
+	if s == nil {
+		return nil
+	}
+
+	if limit <= 0 {
+		limit = defaultAdminDLQLimit
+	}
+
+	maxLimit := s.adminGuardrails.ReplayLimitMax
+	if maxLimit > 0 && limit > maxLimit {
+		return ErrAdminReplayLimitExceeded
+	}
+
+	return nil
+}
+
+func (s *GRPCServer) enforceReplayIDsLimit(ids []string) error {
+	if s == nil {
+		return nil
+	}
+
+	maxIDs := s.adminGuardrails.ReplayIDsMax
+	if maxIDs > 0 && len(ids) > maxIDs {
+		return ErrAdminReplayIDsTooLarge
+	}
+
+	return nil
+}
+
+func (s *GRPCServer) enforceScheduleRun(name string) error {
+	if s == nil || s.scheduleRunLimiter == nil {
+		return nil
+	}
+
+	if s.scheduleRunLimiter.allow(name, time.Now()) {
+		return nil
+	}
+
+	return ErrAdminScheduleRunRateLimited
+}
+
+func adminApprovalTokenFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+
+	meta, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ""
+	}
+
+	values := meta.Get(adminApprovalMetaKey)
+	if len(values) == 0 {
+		return ""
+	}
+
+	return strings.TrimSpace(values[0])
+}

--- a/admin_observability.go
+++ b/admin_observability.go
@@ -1,0 +1,312 @@
+package worker
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// AdminObservability collects lightweight admin service metrics.
+type AdminObservability struct {
+	mu      sync.RWMutex
+	started time.Time
+	http    map[string]*adminMethodMetric
+	grpc    map[string]*adminMethodMetric
+	jobs    adminJobRunMetric
+}
+
+type adminMethodMetric struct {
+	calls     int64
+	errors    int64
+	totalMs   int64
+	maxMs     int64
+	lastCode  string
+	updatedAt time.Time
+}
+
+type adminJobRunMetric struct {
+	running   int64
+	completed int64
+	failed    int64
+	totalMs   int64
+	maxMs     int64
+	lastCode  string
+	updatedAt time.Time
+}
+
+// AdminObservabilitySnapshot is a serializable view of admin metrics.
+type AdminObservabilitySnapshot struct {
+	StartedAt time.Time                               `json:"startedAt"`
+	UptimeSec int64                                   `json:"uptimeSec"`
+	HTTP      map[string]AdminObservabilityMethodStat `json:"http"`
+	GRPC      map[string]AdminObservabilityMethodStat `json:"grpc"`
+	Jobs      AdminObservabilityJobStat               `json:"jobs"`
+}
+
+// AdminObservabilityMethodStat describes aggregate metrics for an HTTP/gRPC method.
+type AdminObservabilityMethodStat struct {
+	Calls       int64     `json:"calls"`
+	Errors      int64     `json:"errors"`
+	TotalMs     int64     `json:"totalMs"`
+	MaxMs       int64     `json:"maxMs"`
+	AvgMs       float64   `json:"avgMs"`
+	LastCode    string    `json:"lastCode"`
+	LastUpdated time.Time `json:"lastUpdated"`
+}
+
+// AdminObservabilityJobStat describes aggregate job-runner outcomes.
+type AdminObservabilityJobStat struct {
+	Running     int64     `json:"running"`
+	Completed   int64     `json:"completed"`
+	Failed      int64     `json:"failed"`
+	TotalMs     int64     `json:"totalMs"`
+	MaxMs       int64     `json:"maxMs"`
+	AvgMs       float64   `json:"avgMs"`
+	LastCode    string    `json:"lastCode"`
+	LastUpdated time.Time `json:"lastUpdated"`
+}
+
+// NewAdminObservability creates an in-memory admin metrics collector.
+func NewAdminObservability() *AdminObservability {
+	return &AdminObservability{
+		started: time.Now().UTC(),
+		http:    make(map[string]*adminMethodMetric),
+		grpc:    make(map[string]*adminMethodMetric),
+	}
+}
+
+// Middleware records per-route HTTP latency and status metrics.
+func (collector *AdminObservability) Middleware(next http.Handler) http.Handler {
+	if collector == nil || next == nil {
+		return next
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		startedAt := time.Now()
+		recorder := &adminResponseRecorder{ResponseWriter: w, statusCode: http.StatusOK}
+		next.ServeHTTP(recorder, r)
+		collector.RecordHTTP(r.Method, r.URL.Path, recorder.statusCode, time.Since(startedAt))
+	})
+}
+
+// UnaryServerInterceptor records gRPC latency and status metrics.
+func (collector *AdminObservability) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req any,
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (any, error) {
+		startedAt := time.Now()
+		resp, err := handler(ctx, req)
+		code := status.Code(err)
+		collector.RecordGRPC(info.FullMethod, code, time.Since(startedAt))
+
+		return resp, err
+	}
+}
+
+// RecordHTTP records HTTP route metrics.
+func (collector *AdminObservability) RecordHTTP(method, route string, statusCode int, duration time.Duration) {
+	if collector == nil {
+		return
+	}
+
+	key := method + " " + route
+	collector.recordMethodMetric(collector.http, key, statusCode >= http.StatusBadRequest, http.StatusText(statusCode), duration)
+}
+
+// RecordGRPC records gRPC method metrics.
+func (collector *AdminObservability) RecordGRPC(method string, code codes.Code, duration time.Duration) {
+	if collector == nil {
+		return
+	}
+
+	collector.recordMethodMetric(
+		collector.grpc,
+		method,
+		code != codes.OK,
+		code.String(),
+		duration,
+	)
+}
+
+// RecordJobQueued increments running gauge when a job run starts.
+func (collector *AdminObservability) RecordJobQueued() {
+	if collector == nil {
+		return
+	}
+
+	collector.mu.Lock()
+	defer collector.mu.Unlock()
+
+	collector.jobs.running++
+	collector.jobs.updatedAt = time.Now().UTC()
+}
+
+// RecordJobOutcome records a final job status and duration.
+func (collector *AdminObservability) RecordJobOutcome(statusCode string, duration time.Duration) {
+	if collector == nil {
+		return
+	}
+
+	collector.mu.Lock()
+	defer collector.mu.Unlock()
+
+	if collector.jobs.running > 0 {
+		collector.jobs.running--
+	}
+
+	statusCode = normalizeMetricCode(statusCode)
+	switch statusCode {
+	case "completed":
+		collector.jobs.completed++
+	default:
+		collector.jobs.failed++
+	}
+
+	ms := durationToMillis(duration)
+
+	collector.jobs.totalMs += ms
+	if ms > collector.jobs.maxMs {
+		collector.jobs.maxMs = ms
+	}
+
+	collector.jobs.lastCode = statusCode
+	collector.jobs.updatedAt = time.Now().UTC()
+}
+
+// Snapshot returns a consistent view of collected metrics.
+func (collector *AdminObservability) Snapshot() AdminObservabilitySnapshot {
+	if collector == nil {
+		return AdminObservabilitySnapshot{}
+	}
+
+	collector.mu.RLock()
+	defer collector.mu.RUnlock()
+
+	now := time.Now().UTC()
+	snapshot := AdminObservabilitySnapshot{
+		StartedAt: collector.started,
+		UptimeSec: int64(now.Sub(collector.started).Seconds()),
+		HTTP:      make(map[string]AdminObservabilityMethodStat, len(collector.http)),
+		GRPC:      make(map[string]AdminObservabilityMethodStat, len(collector.grpc)),
+		Jobs:      toJobSnapshot(collector.jobs),
+	}
+
+	for key, metric := range collector.http {
+		snapshot.HTTP[key] = toMethodSnapshot(metric)
+	}
+
+	for key, metric := range collector.grpc {
+		snapshot.GRPC[key] = toMethodSnapshot(metric)
+	}
+
+	return snapshot
+}
+
+func (collector *AdminObservability) recordMethodMetric(
+	target map[string]*adminMethodMetric,
+	key string,
+	isError bool,
+	lastCode string,
+	duration time.Duration,
+) {
+	collector.mu.Lock()
+	defer collector.mu.Unlock()
+
+	metric, ok := target[key]
+	if !ok {
+		metric = &adminMethodMetric{}
+		target[key] = metric
+	}
+
+	metric.calls++
+	if isError {
+		metric.errors++
+	}
+
+	ms := durationToMillis(duration)
+
+	metric.totalMs += ms
+	if ms > metric.maxMs {
+		metric.maxMs = ms
+	}
+
+	metric.lastCode = normalizeMetricCode(lastCode)
+	metric.updatedAt = time.Now().UTC()
+}
+
+func toMethodSnapshot(metric *adminMethodMetric) AdminObservabilityMethodStat {
+	if metric == nil {
+		return AdminObservabilityMethodStat{}
+	}
+
+	avgMs := float64(0)
+	if metric.calls > 0 {
+		avgMs = float64(metric.totalMs) / float64(metric.calls)
+	}
+
+	return AdminObservabilityMethodStat{
+		Calls:       metric.calls,
+		Errors:      metric.errors,
+		TotalMs:     metric.totalMs,
+		MaxMs:       metric.maxMs,
+		AvgMs:       avgMs,
+		LastCode:    metric.lastCode,
+		LastUpdated: metric.updatedAt,
+	}
+}
+
+func toJobSnapshot(metric adminJobRunMetric) AdminObservabilityJobStat {
+	total := metric.completed + metric.failed
+
+	avgMs := float64(0)
+	if total > 0 {
+		avgMs = float64(metric.totalMs) / float64(total)
+	}
+
+	return AdminObservabilityJobStat{
+		Running:     metric.running,
+		Completed:   metric.completed,
+		Failed:      metric.failed,
+		TotalMs:     metric.totalMs,
+		MaxMs:       metric.maxMs,
+		AvgMs:       avgMs,
+		LastCode:    metric.lastCode,
+		LastUpdated: metric.updatedAt,
+	}
+}
+
+func durationToMillis(duration time.Duration) int64 {
+	if duration <= 0 {
+		return 0
+	}
+
+	return duration.Milliseconds()
+}
+
+func normalizeMetricCode(code string) string {
+	code = strings.TrimSpace(strings.ToLower(code))
+	if code == "" {
+		return "unknown"
+	}
+
+	return code
+}
+
+type adminResponseRecorder struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (recorder *adminResponseRecorder) WriteHeader(statusCode int) {
+	recorder.statusCode = statusCode
+	recorder.ResponseWriter.WriteHeader(statusCode)
+}

--- a/compose.admin.yaml
+++ b/compose.admin.yaml
@@ -35,8 +35,12 @@ services:
       WORKER_ADMIN_TLS_CERT: /certs/server.crt
       WORKER_ADMIN_TLS_KEY: /certs/server.key
       WORKER_ADMIN_TLS_CA: /certs/ca.crt
+      WORKER_ADMIN_JOB_TARBALL_DIR: /workspace
+      WORKER_ADMIN_AUDIT_EVENT_LIMIT: "500"
+      WORKER_ADMIN_AUDIT_EXPORT_LIMIT_MAX: "5000"
     volumes:
       - ./certs:/certs:ro
+      - ./:/workspace:ro
     ports:
       - "8081:8081"
     depends_on:
@@ -62,6 +66,7 @@ services:
       WORKER_JOB_EVENT_DIR: /var/lib/go-worker/job-events
       WORKER_JOB_EVENT_MAX_ENTRIES: "10000"
       WORKER_JOB_EVENT_CACHE_TTL: 5s
+      WORKER_ADMIN_AUDIT_EVENT_LIMIT: "500"
       DOCKER_BUILDKIT: "1"
     ports:
       - "50052:50052"
@@ -84,10 +89,8 @@ services:
       WORKER_ADMIN_MTLS_KEY: /certs/client.key
       WORKER_ADMIN_MTLS_CA: /certs/ca.crt
       WORKER_ADMIN_PASSWORD: change-me
-      WORKER_ADMIN_JOB_TARBALL_DIR: /workspace
     volumes:
       - ./certs:/certs:ro
-      - ./:/workspace:ro
     ports:
       - "3000:3000"
     depends_on:

--- a/cron_events.go
+++ b/cron_events.go
@@ -128,24 +128,24 @@ func (tm *TaskManager) appendCronEventLocked(event AdminScheduleEvent) {
 func cronStatusLabel(status TaskStatus) string {
 	switch status {
 	case RateLimited:
-		return "rate_limited"
+		return adminStatusRateLimited
 	case Queued:
-		return "queued"
+		return adminStatusQueued
 	case Running:
-		return "running"
+		return adminStatusRunning
 	case ContextDeadlineReached:
-		return "deadline"
+		return adminStatusDeadline
 	case Completed:
-		return "completed"
+		return adminStatusCompleted
 	case Failed:
-		return "failed"
+		return adminStatusFailed
 	case Cancelled:
-		return "cancelled"
+		return adminStatusCancelled
 	case Invalid:
-		return "invalid"
+		return adminStatusInvalid
 	}
 
-	return "unknown"
+	return adminStatusUnknown
 }
 
 func cronFinishedAt(task *Task, status TaskStatus) time.Time {

--- a/job_events.go
+++ b/job_events.go
@@ -13,6 +13,15 @@ const (
 	defaultAdminJobEventLimit   = 200
 	jobEventResultMaxLen        = 240
 	adminJobEventPersistTimeout = 2 * time.Second
+	adminStatusRateLimited      = "rate_limited"
+	adminStatusQueued           = "queued"
+	adminStatusRunning          = "running"
+	adminStatusDeadline         = "deadline"
+	adminStatusCompleted        = "completed"
+	adminStatusFailed           = "failed"
+	adminStatusCancelled        = "cancelled"
+	adminStatusInvalid          = "invalid"
+	adminStatusUnknown          = "unknown"
 )
 
 type adminJobEventRecorder interface {
@@ -207,24 +216,24 @@ func (tm *TaskManager) persistJobEvent(ctx context.Context, event AdminJobEvent)
 func jobStatusLabel(status TaskStatus) string {
 	switch status {
 	case RateLimited:
-		return "rate_limited"
+		return adminStatusRateLimited
 	case Queued:
-		return "queued"
+		return adminStatusQueued
 	case Running:
-		return "running"
+		return adminStatusRunning
 	case ContextDeadlineReached:
-		return "deadline"
+		return adminStatusDeadline
 	case Completed:
-		return "completed"
+		return adminStatusCompleted
 	case Failed:
-		return "failed"
+		return adminStatusFailed
 	case Cancelled:
-		return "cancelled"
+		return adminStatusCancelled
 	case Invalid:
-		return "invalid"
+		return adminStatusInvalid
 	}
 
-	return "unknown"
+	return adminStatusUnknown
 }
 
 func jobFinishedAt(task *Task, status TaskStatus) time.Time {

--- a/options.go
+++ b/options.go
@@ -11,14 +11,15 @@ const (
 type TaskManagerOption func(*taskManagerConfig)
 
 type taskManagerConfig struct {
-	maxWorkers     int
-	maxTasks       int
-	tasksPerSecond float64
-	timeout        time.Duration
-	retryDelay     time.Duration
-	maxRetries     int
-	defaultQueue   string
-	queueWeights   map[string]int
+	maxWorkers      int
+	maxTasks        int
+	tasksPerSecond  float64
+	timeout         time.Duration
+	retryDelay      time.Duration
+	maxRetries      int
+	defaultQueue    string
+	queueWeights    map[string]int
+	auditEventLimit int
 
 	durableBackend      DurableBackend
 	durableHandlers     map[string]DurableHandlerSpec
@@ -47,6 +48,7 @@ func defaultTaskManagerConfig() taskManagerConfig {
 		durableLeaseRenewal: 0,
 		durableCodec:        ProtoDurableCodec{},
 		cronLocation:        time.UTC,
+		auditEventLimit:     defaultAdminAuditEventLimit,
 	}
 }
 
@@ -170,5 +172,12 @@ func WithCronLocation(location *time.Location) TaskManagerOption {
 		if location != nil {
 			cfg.cronLocation = location
 		}
+	}
+}
+
+// WithAdminAuditEventLimit sets the maximum number of in-memory admin audit events.
+func WithAdminAuditEventLimit(limit int) TaskManagerOption {
+	return func(cfg *taskManagerConfig) {
+		cfg.auditEventLimit = limit
 	}
 }

--- a/pkg/worker/v1/admin.pb.go
+++ b/pkg/worker/v1/admin.pb.go
@@ -7,11 +7,12 @@
 package workerpb
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -2525,6 +2526,218 @@ func (x *ListJobEventsResponse) GetEvents() []*JobEvent {
 	return nil
 }
 
+type AuditEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	AtMs          int64                  `protobuf:"varint,1,opt,name=at_ms,json=atMs,proto3" json:"at_ms,omitempty"`
+	Actor         string                 `protobuf:"bytes,2,opt,name=actor,proto3" json:"actor,omitempty"`
+	RequestId     string                 `protobuf:"bytes,3,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	Action        string                 `protobuf:"bytes,4,opt,name=action,proto3" json:"action,omitempty"`
+	Target        string                 `protobuf:"bytes,5,opt,name=target,proto3" json:"target,omitempty"`
+	Status        string                 `protobuf:"bytes,6,opt,name=status,proto3" json:"status,omitempty"`
+	PayloadHash   string                 `protobuf:"bytes,7,opt,name=payload_hash,json=payloadHash,proto3" json:"payload_hash,omitempty"`
+	Detail        string                 `protobuf:"bytes,8,opt,name=detail,proto3" json:"detail,omitempty"`
+	Metadata      map[string]string      `protobuf:"bytes,9,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AuditEvent) Reset() {
+	*x = AuditEvent{}
+	mi := &file_worker_v1_admin_proto_msgTypes[44]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AuditEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AuditEvent) ProtoMessage() {}
+
+func (x *AuditEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_worker_v1_admin_proto_msgTypes[44]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AuditEvent.ProtoReflect.Descriptor instead.
+func (*AuditEvent) Descriptor() ([]byte, []int) {
+	return file_worker_v1_admin_proto_rawDescGZIP(), []int{44}
+}
+
+func (x *AuditEvent) GetAtMs() int64 {
+	if x != nil {
+		return x.AtMs
+	}
+	return 0
+}
+
+func (x *AuditEvent) GetActor() string {
+	if x != nil {
+		return x.Actor
+	}
+	return ""
+}
+
+func (x *AuditEvent) GetRequestId() string {
+	if x != nil {
+		return x.RequestId
+	}
+	return ""
+}
+
+func (x *AuditEvent) GetAction() string {
+	if x != nil {
+		return x.Action
+	}
+	return ""
+}
+
+func (x *AuditEvent) GetTarget() string {
+	if x != nil {
+		return x.Target
+	}
+	return ""
+}
+
+func (x *AuditEvent) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *AuditEvent) GetPayloadHash() string {
+	if x != nil {
+		return x.PayloadHash
+	}
+	return ""
+}
+
+func (x *AuditEvent) GetDetail() string {
+	if x != nil {
+		return x.Detail
+	}
+	return ""
+}
+
+func (x *AuditEvent) GetMetadata() map[string]string {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+type ListAuditEventsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Action        string                 `protobuf:"bytes,1,opt,name=action,proto3" json:"action,omitempty"`
+	Target        string                 `protobuf:"bytes,2,opt,name=target,proto3" json:"target,omitempty"`
+	Limit         int32                  `protobuf:"varint,3,opt,name=limit,proto3" json:"limit,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListAuditEventsRequest) Reset() {
+	*x = ListAuditEventsRequest{}
+	mi := &file_worker_v1_admin_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListAuditEventsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListAuditEventsRequest) ProtoMessage() {}
+
+func (x *ListAuditEventsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_worker_v1_admin_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListAuditEventsRequest.ProtoReflect.Descriptor instead.
+func (*ListAuditEventsRequest) Descriptor() ([]byte, []int) {
+	return file_worker_v1_admin_proto_rawDescGZIP(), []int{45}
+}
+
+func (x *ListAuditEventsRequest) GetAction() string {
+	if x != nil {
+		return x.Action
+	}
+	return ""
+}
+
+func (x *ListAuditEventsRequest) GetTarget() string {
+	if x != nil {
+		return x.Target
+	}
+	return ""
+}
+
+func (x *ListAuditEventsRequest) GetLimit() int32 {
+	if x != nil {
+		return x.Limit
+	}
+	return 0
+}
+
+type ListAuditEventsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Events        []*AuditEvent          `protobuf:"bytes,1,rep,name=events,proto3" json:"events,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListAuditEventsResponse) Reset() {
+	*x = ListAuditEventsResponse{}
+	mi := &file_worker_v1_admin_proto_msgTypes[46]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListAuditEventsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListAuditEventsResponse) ProtoMessage() {}
+
+func (x *ListAuditEventsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_worker_v1_admin_proto_msgTypes[46]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListAuditEventsResponse.ProtoReflect.Descriptor instead.
+func (*ListAuditEventsResponse) Descriptor() ([]byte, []int) {
+	return file_worker_v1_admin_proto_rawDescGZIP(), []int{46}
+}
+
+func (x *ListAuditEventsResponse) GetEvents() []*AuditEvent {
+	if x != nil {
+		return x.Events
+	}
+	return nil
+}
+
 type GetJobRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -2534,7 +2747,7 @@ type GetJobRequest struct {
 
 func (x *GetJobRequest) Reset() {
 	*x = GetJobRequest{}
-	mi := &file_worker_v1_admin_proto_msgTypes[44]
+	mi := &file_worker_v1_admin_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2546,7 +2759,7 @@ func (x *GetJobRequest) String() string {
 func (*GetJobRequest) ProtoMessage() {}
 
 func (x *GetJobRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_worker_v1_admin_proto_msgTypes[44]
+	mi := &file_worker_v1_admin_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2559,7 +2772,7 @@ func (x *GetJobRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetJobRequest.ProtoReflect.Descriptor instead.
 func (*GetJobRequest) Descriptor() ([]byte, []int) {
-	return file_worker_v1_admin_proto_rawDescGZIP(), []int{44}
+	return file_worker_v1_admin_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *GetJobRequest) GetName() string {
@@ -2578,7 +2791,7 @@ type GetJobResponse struct {
 
 func (x *GetJobResponse) Reset() {
 	*x = GetJobResponse{}
-	mi := &file_worker_v1_admin_proto_msgTypes[45]
+	mi := &file_worker_v1_admin_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2590,7 +2803,7 @@ func (x *GetJobResponse) String() string {
 func (*GetJobResponse) ProtoMessage() {}
 
 func (x *GetJobResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_worker_v1_admin_proto_msgTypes[45]
+	mi := &file_worker_v1_admin_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2603,7 +2816,7 @@ func (x *GetJobResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetJobResponse.ProtoReflect.Descriptor instead.
 func (*GetJobResponse) Descriptor() ([]byte, []int) {
-	return file_worker_v1_admin_proto_rawDescGZIP(), []int{45}
+	return file_worker_v1_admin_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *GetJobResponse) GetJob() *Job {
@@ -2622,7 +2835,7 @@ type UpsertJobRequest struct {
 
 func (x *UpsertJobRequest) Reset() {
 	*x = UpsertJobRequest{}
-	mi := &file_worker_v1_admin_proto_msgTypes[46]
+	mi := &file_worker_v1_admin_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2634,7 +2847,7 @@ func (x *UpsertJobRequest) String() string {
 func (*UpsertJobRequest) ProtoMessage() {}
 
 func (x *UpsertJobRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_worker_v1_admin_proto_msgTypes[46]
+	mi := &file_worker_v1_admin_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2647,7 +2860,7 @@ func (x *UpsertJobRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpsertJobRequest.ProtoReflect.Descriptor instead.
 func (*UpsertJobRequest) Descriptor() ([]byte, []int) {
-	return file_worker_v1_admin_proto_rawDescGZIP(), []int{46}
+	return file_worker_v1_admin_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *UpsertJobRequest) GetSpec() *JobSpec {
@@ -2666,7 +2879,7 @@ type UpsertJobResponse struct {
 
 func (x *UpsertJobResponse) Reset() {
 	*x = UpsertJobResponse{}
-	mi := &file_worker_v1_admin_proto_msgTypes[47]
+	mi := &file_worker_v1_admin_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2678,7 +2891,7 @@ func (x *UpsertJobResponse) String() string {
 func (*UpsertJobResponse) ProtoMessage() {}
 
 func (x *UpsertJobResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_worker_v1_admin_proto_msgTypes[47]
+	mi := &file_worker_v1_admin_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2691,7 +2904,7 @@ func (x *UpsertJobResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpsertJobResponse.ProtoReflect.Descriptor instead.
 func (*UpsertJobResponse) Descriptor() ([]byte, []int) {
-	return file_worker_v1_admin_proto_rawDescGZIP(), []int{47}
+	return file_worker_v1_admin_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *UpsertJobResponse) GetJob() *Job {
@@ -2710,7 +2923,7 @@ type DeleteJobRequest struct {
 
 func (x *DeleteJobRequest) Reset() {
 	*x = DeleteJobRequest{}
-	mi := &file_worker_v1_admin_proto_msgTypes[48]
+	mi := &file_worker_v1_admin_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2722,7 +2935,7 @@ func (x *DeleteJobRequest) String() string {
 func (*DeleteJobRequest) ProtoMessage() {}
 
 func (x *DeleteJobRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_worker_v1_admin_proto_msgTypes[48]
+	mi := &file_worker_v1_admin_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2735,7 +2948,7 @@ func (x *DeleteJobRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteJobRequest.ProtoReflect.Descriptor instead.
 func (*DeleteJobRequest) Descriptor() ([]byte, []int) {
-	return file_worker_v1_admin_proto_rawDescGZIP(), []int{48}
+	return file_worker_v1_admin_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *DeleteJobRequest) GetName() string {
@@ -2754,7 +2967,7 @@ type DeleteJobResponse struct {
 
 func (x *DeleteJobResponse) Reset() {
 	*x = DeleteJobResponse{}
-	mi := &file_worker_v1_admin_proto_msgTypes[49]
+	mi := &file_worker_v1_admin_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2766,7 +2979,7 @@ func (x *DeleteJobResponse) String() string {
 func (*DeleteJobResponse) ProtoMessage() {}
 
 func (x *DeleteJobResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_worker_v1_admin_proto_msgTypes[49]
+	mi := &file_worker_v1_admin_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2779,7 +2992,7 @@ func (x *DeleteJobResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteJobResponse.ProtoReflect.Descriptor instead.
 func (*DeleteJobResponse) Descriptor() ([]byte, []int) {
-	return file_worker_v1_admin_proto_rawDescGZIP(), []int{49}
+	return file_worker_v1_admin_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *DeleteJobResponse) GetDeleted() bool {
@@ -2798,7 +3011,7 @@ type RunJobRequest struct {
 
 func (x *RunJobRequest) Reset() {
 	*x = RunJobRequest{}
-	mi := &file_worker_v1_admin_proto_msgTypes[50]
+	mi := &file_worker_v1_admin_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2810,7 +3023,7 @@ func (x *RunJobRequest) String() string {
 func (*RunJobRequest) ProtoMessage() {}
 
 func (x *RunJobRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_worker_v1_admin_proto_msgTypes[50]
+	mi := &file_worker_v1_admin_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2823,7 +3036,7 @@ func (x *RunJobRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunJobRequest.ProtoReflect.Descriptor instead.
 func (*RunJobRequest) Descriptor() ([]byte, []int) {
-	return file_worker_v1_admin_proto_rawDescGZIP(), []int{50}
+	return file_worker_v1_admin_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *RunJobRequest) GetName() string {
@@ -2842,7 +3055,7 @@ type RunJobResponse struct {
 
 func (x *RunJobResponse) Reset() {
 	*x = RunJobResponse{}
-	mi := &file_worker_v1_admin_proto_msgTypes[51]
+	mi := &file_worker_v1_admin_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2854,7 +3067,7 @@ func (x *RunJobResponse) String() string {
 func (*RunJobResponse) ProtoMessage() {}
 
 func (x *RunJobResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_worker_v1_admin_proto_msgTypes[51]
+	mi := &file_worker_v1_admin_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2867,7 +3080,7 @@ func (x *RunJobResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunJobResponse.ProtoReflect.Descriptor instead.
 func (*RunJobResponse) Descriptor() ([]byte, []int) {
-	return file_worker_v1_admin_proto_rawDescGZIP(), []int{51}
+	return file_worker_v1_admin_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *RunJobResponse) GetTaskId() string {
@@ -2890,7 +3103,7 @@ type DLQEntry struct {
 
 func (x *DLQEntry) Reset() {
 	*x = DLQEntry{}
-	mi := &file_worker_v1_admin_proto_msgTypes[52]
+	mi := &file_worker_v1_admin_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2902,7 +3115,7 @@ func (x *DLQEntry) String() string {
 func (*DLQEntry) ProtoMessage() {}
 
 func (x *DLQEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_worker_v1_admin_proto_msgTypes[52]
+	mi := &file_worker_v1_admin_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2915,7 +3128,7 @@ func (x *DLQEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DLQEntry.ProtoReflect.Descriptor instead.
 func (*DLQEntry) Descriptor() ([]byte, []int) {
-	return file_worker_v1_admin_proto_rawDescGZIP(), []int{52}
+	return file_worker_v1_admin_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *DLQEntry) GetId() string {
@@ -2971,7 +3184,7 @@ type DLQEntryDetail struct {
 
 func (x *DLQEntryDetail) Reset() {
 	*x = DLQEntryDetail{}
-	mi := &file_worker_v1_admin_proto_msgTypes[53]
+	mi := &file_worker_v1_admin_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2983,7 +3196,7 @@ func (x *DLQEntryDetail) String() string {
 func (*DLQEntryDetail) ProtoMessage() {}
 
 func (x *DLQEntryDetail) ProtoReflect() protoreflect.Message {
-	mi := &file_worker_v1_admin_proto_msgTypes[53]
+	mi := &file_worker_v1_admin_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2996,7 +3209,7 @@ func (x *DLQEntryDetail) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DLQEntryDetail.ProtoReflect.Descriptor instead.
 func (*DLQEntryDetail) Descriptor() ([]byte, []int) {
-	return file_worker_v1_admin_proto_rawDescGZIP(), []int{53}
+	return file_worker_v1_admin_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *DLQEntryDetail) GetId() string {
@@ -3078,7 +3291,7 @@ type GetDLQEntryRequest struct {
 
 func (x *GetDLQEntryRequest) Reset() {
 	*x = GetDLQEntryRequest{}
-	mi := &file_worker_v1_admin_proto_msgTypes[54]
+	mi := &file_worker_v1_admin_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3090,7 +3303,7 @@ func (x *GetDLQEntryRequest) String() string {
 func (*GetDLQEntryRequest) ProtoMessage() {}
 
 func (x *GetDLQEntryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_worker_v1_admin_proto_msgTypes[54]
+	mi := &file_worker_v1_admin_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3103,7 +3316,7 @@ func (x *GetDLQEntryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDLQEntryRequest.ProtoReflect.Descriptor instead.
 func (*GetDLQEntryRequest) Descriptor() ([]byte, []int) {
-	return file_worker_v1_admin_proto_rawDescGZIP(), []int{54}
+	return file_worker_v1_admin_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *GetDLQEntryRequest) GetId() string {
@@ -3122,7 +3335,7 @@ type GetDLQEntryResponse struct {
 
 func (x *GetDLQEntryResponse) Reset() {
 	*x = GetDLQEntryResponse{}
-	mi := &file_worker_v1_admin_proto_msgTypes[55]
+	mi := &file_worker_v1_admin_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3134,7 +3347,7 @@ func (x *GetDLQEntryResponse) String() string {
 func (*GetDLQEntryResponse) ProtoMessage() {}
 
 func (x *GetDLQEntryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_worker_v1_admin_proto_msgTypes[55]
+	mi := &file_worker_v1_admin_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3147,7 +3360,7 @@ func (x *GetDLQEntryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDLQEntryResponse.ProtoReflect.Descriptor instead.
 func (*GetDLQEntryResponse) Descriptor() ([]byte, []int) {
-	return file_worker_v1_admin_proto_rawDescGZIP(), []int{55}
+	return file_worker_v1_admin_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *GetDLQEntryResponse) GetEntry() *DLQEntryDetail {
@@ -3170,7 +3383,7 @@ type ListDLQRequest struct {
 
 func (x *ListDLQRequest) Reset() {
 	*x = ListDLQRequest{}
-	mi := &file_worker_v1_admin_proto_msgTypes[56]
+	mi := &file_worker_v1_admin_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3182,7 +3395,7 @@ func (x *ListDLQRequest) String() string {
 func (*ListDLQRequest) ProtoMessage() {}
 
 func (x *ListDLQRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_worker_v1_admin_proto_msgTypes[56]
+	mi := &file_worker_v1_admin_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3195,7 +3408,7 @@ func (x *ListDLQRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDLQRequest.ProtoReflect.Descriptor instead.
 func (*ListDLQRequest) Descriptor() ([]byte, []int) {
-	return file_worker_v1_admin_proto_rawDescGZIP(), []int{56}
+	return file_worker_v1_admin_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *ListDLQRequest) GetLimit() int32 {
@@ -3243,7 +3456,7 @@ type ListDLQResponse struct {
 
 func (x *ListDLQResponse) Reset() {
 	*x = ListDLQResponse{}
-	mi := &file_worker_v1_admin_proto_msgTypes[57]
+	mi := &file_worker_v1_admin_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3255,7 +3468,7 @@ func (x *ListDLQResponse) String() string {
 func (*ListDLQResponse) ProtoMessage() {}
 
 func (x *ListDLQResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_worker_v1_admin_proto_msgTypes[57]
+	mi := &file_worker_v1_admin_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3268,7 +3481,7 @@ func (x *ListDLQResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDLQResponse.ProtoReflect.Descriptor instead.
 func (*ListDLQResponse) Descriptor() ([]byte, []int) {
-	return file_worker_v1_admin_proto_rawDescGZIP(), []int{57}
+	return file_worker_v1_admin_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *ListDLQResponse) GetEntries() []*DLQEntry {
@@ -3293,7 +3506,7 @@ type PauseDequeueRequest struct {
 
 func (x *PauseDequeueRequest) Reset() {
 	*x = PauseDequeueRequest{}
-	mi := &file_worker_v1_admin_proto_msgTypes[58]
+	mi := &file_worker_v1_admin_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3305,7 +3518,7 @@ func (x *PauseDequeueRequest) String() string {
 func (*PauseDequeueRequest) ProtoMessage() {}
 
 func (x *PauseDequeueRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_worker_v1_admin_proto_msgTypes[58]
+	mi := &file_worker_v1_admin_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3318,7 +3531,7 @@ func (x *PauseDequeueRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PauseDequeueRequest.ProtoReflect.Descriptor instead.
 func (*PauseDequeueRequest) Descriptor() ([]byte, []int) {
-	return file_worker_v1_admin_proto_rawDescGZIP(), []int{58}
+	return file_worker_v1_admin_proto_rawDescGZIP(), []int{61}
 }
 
 type PauseDequeueResponse struct {
@@ -3330,7 +3543,7 @@ type PauseDequeueResponse struct {
 
 func (x *PauseDequeueResponse) Reset() {
 	*x = PauseDequeueResponse{}
-	mi := &file_worker_v1_admin_proto_msgTypes[59]
+	mi := &file_worker_v1_admin_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3342,7 +3555,7 @@ func (x *PauseDequeueResponse) String() string {
 func (*PauseDequeueResponse) ProtoMessage() {}
 
 func (x *PauseDequeueResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_worker_v1_admin_proto_msgTypes[59]
+	mi := &file_worker_v1_admin_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3355,7 +3568,7 @@ func (x *PauseDequeueResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PauseDequeueResponse.ProtoReflect.Descriptor instead.
 func (*PauseDequeueResponse) Descriptor() ([]byte, []int) {
-	return file_worker_v1_admin_proto_rawDescGZIP(), []int{59}
+	return file_worker_v1_admin_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *PauseDequeueResponse) GetPaused() bool {
@@ -3373,7 +3586,7 @@ type ResumeDequeueRequest struct {
 
 func (x *ResumeDequeueRequest) Reset() {
 	*x = ResumeDequeueRequest{}
-	mi := &file_worker_v1_admin_proto_msgTypes[60]
+	mi := &file_worker_v1_admin_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3385,7 +3598,7 @@ func (x *ResumeDequeueRequest) String() string {
 func (*ResumeDequeueRequest) ProtoMessage() {}
 
 func (x *ResumeDequeueRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_worker_v1_admin_proto_msgTypes[60]
+	mi := &file_worker_v1_admin_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3398,7 +3611,7 @@ func (x *ResumeDequeueRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeDequeueRequest.ProtoReflect.Descriptor instead.
 func (*ResumeDequeueRequest) Descriptor() ([]byte, []int) {
-	return file_worker_v1_admin_proto_rawDescGZIP(), []int{60}
+	return file_worker_v1_admin_proto_rawDescGZIP(), []int{63}
 }
 
 type ResumeDequeueResponse struct {
@@ -3410,7 +3623,7 @@ type ResumeDequeueResponse struct {
 
 func (x *ResumeDequeueResponse) Reset() {
 	*x = ResumeDequeueResponse{}
-	mi := &file_worker_v1_admin_proto_msgTypes[61]
+	mi := &file_worker_v1_admin_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3422,7 +3635,7 @@ func (x *ResumeDequeueResponse) String() string {
 func (*ResumeDequeueResponse) ProtoMessage() {}
 
 func (x *ResumeDequeueResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_worker_v1_admin_proto_msgTypes[61]
+	mi := &file_worker_v1_admin_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3435,7 +3648,7 @@ func (x *ResumeDequeueResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResumeDequeueResponse.ProtoReflect.Descriptor instead.
 func (*ResumeDequeueResponse) Descriptor() ([]byte, []int) {
-	return file_worker_v1_admin_proto_rawDescGZIP(), []int{61}
+	return file_worker_v1_admin_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *ResumeDequeueResponse) GetPaused() bool {
@@ -3454,7 +3667,7 @@ type ReplayDLQRequest struct {
 
 func (x *ReplayDLQRequest) Reset() {
 	*x = ReplayDLQRequest{}
-	mi := &file_worker_v1_admin_proto_msgTypes[62]
+	mi := &file_worker_v1_admin_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3466,7 +3679,7 @@ func (x *ReplayDLQRequest) String() string {
 func (*ReplayDLQRequest) ProtoMessage() {}
 
 func (x *ReplayDLQRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_worker_v1_admin_proto_msgTypes[62]
+	mi := &file_worker_v1_admin_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3479,7 +3692,7 @@ func (x *ReplayDLQRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplayDLQRequest.ProtoReflect.Descriptor instead.
 func (*ReplayDLQRequest) Descriptor() ([]byte, []int) {
-	return file_worker_v1_admin_proto_rawDescGZIP(), []int{62}
+	return file_worker_v1_admin_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *ReplayDLQRequest) GetLimit() int32 {
@@ -3498,7 +3711,7 @@ type ReplayDLQResponse struct {
 
 func (x *ReplayDLQResponse) Reset() {
 	*x = ReplayDLQResponse{}
-	mi := &file_worker_v1_admin_proto_msgTypes[63]
+	mi := &file_worker_v1_admin_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3510,7 +3723,7 @@ func (x *ReplayDLQResponse) String() string {
 func (*ReplayDLQResponse) ProtoMessage() {}
 
 func (x *ReplayDLQResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_worker_v1_admin_proto_msgTypes[63]
+	mi := &file_worker_v1_admin_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3523,7 +3736,7 @@ func (x *ReplayDLQResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplayDLQResponse.ProtoReflect.Descriptor instead.
 func (*ReplayDLQResponse) Descriptor() ([]byte, []int) {
-	return file_worker_v1_admin_proto_rawDescGZIP(), []int{63}
+	return file_worker_v1_admin_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *ReplayDLQResponse) GetMoved() int32 {
@@ -3542,7 +3755,7 @@ type ReplayDLQByIDRequest struct {
 
 func (x *ReplayDLQByIDRequest) Reset() {
 	*x = ReplayDLQByIDRequest{}
-	mi := &file_worker_v1_admin_proto_msgTypes[64]
+	mi := &file_worker_v1_admin_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3554,7 +3767,7 @@ func (x *ReplayDLQByIDRequest) String() string {
 func (*ReplayDLQByIDRequest) ProtoMessage() {}
 
 func (x *ReplayDLQByIDRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_worker_v1_admin_proto_msgTypes[64]
+	mi := &file_worker_v1_admin_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3567,7 +3780,7 @@ func (x *ReplayDLQByIDRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplayDLQByIDRequest.ProtoReflect.Descriptor instead.
 func (*ReplayDLQByIDRequest) Descriptor() ([]byte, []int) {
-	return file_worker_v1_admin_proto_rawDescGZIP(), []int{64}
+	return file_worker_v1_admin_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *ReplayDLQByIDRequest) GetIds() []string {
@@ -3586,7 +3799,7 @@ type ReplayDLQByIDResponse struct {
 
 func (x *ReplayDLQByIDResponse) Reset() {
 	*x = ReplayDLQByIDResponse{}
-	mi := &file_worker_v1_admin_proto_msgTypes[65]
+	mi := &file_worker_v1_admin_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3598,7 +3811,7 @@ func (x *ReplayDLQByIDResponse) String() string {
 func (*ReplayDLQByIDResponse) ProtoMessage() {}
 
 func (x *ReplayDLQByIDResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_worker_v1_admin_proto_msgTypes[65]
+	mi := &file_worker_v1_admin_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3611,7 +3824,7 @@ func (x *ReplayDLQByIDResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplayDLQByIDResponse.ProtoReflect.Descriptor instead.
 func (*ReplayDLQByIDResponse) Descriptor() ([]byte, []int) {
-	return file_worker_v1_admin_proto_rawDescGZIP(), []int{65}
+	return file_worker_v1_admin_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *ReplayDLQByIDResponse) GetMoved() int32 {
@@ -3805,7 +4018,28 @@ const file_worker_v1_admin_proto_rawDesc = "" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
 	"\x05limit\x18\x02 \x01(\x05R\x05limit\"D\n" +
 	"\x15ListJobEventsResponse\x12+\n" +
-	"\x06events\x18\x01 \x03(\v2\x13.worker.v1.JobEventR\x06events\"#\n" +
+	"\x06events\x18\x01 \x03(\v2\x13.worker.v1.JobEventR\x06events\"\xd7\x02\n" +
+	"\n" +
+	"AuditEvent\x12\x13\n" +
+	"\x05at_ms\x18\x01 \x01(\x03R\x04atMs\x12\x14\n" +
+	"\x05actor\x18\x02 \x01(\tR\x05actor\x12\x1d\n" +
+	"\n" +
+	"request_id\x18\x03 \x01(\tR\trequestId\x12\x16\n" +
+	"\x06action\x18\x04 \x01(\tR\x06action\x12\x16\n" +
+	"\x06target\x18\x05 \x01(\tR\x06target\x12\x16\n" +
+	"\x06status\x18\x06 \x01(\tR\x06status\x12!\n" +
+	"\fpayload_hash\x18\a \x01(\tR\vpayloadHash\x12\x16\n" +
+	"\x06detail\x18\b \x01(\tR\x06detail\x12?\n" +
+	"\bmetadata\x18\t \x03(\v2#.worker.v1.AuditEvent.MetadataEntryR\bmetadata\x1a;\n" +
+	"\rMetadataEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"^\n" +
+	"\x16ListAuditEventsRequest\x12\x16\n" +
+	"\x06action\x18\x01 \x01(\tR\x06action\x12\x16\n" +
+	"\x06target\x18\x02 \x01(\tR\x06target\x12\x14\n" +
+	"\x05limit\x18\x03 \x01(\x05R\x05limit\"H\n" +
+	"\x17ListAuditEventsResponse\x12-\n" +
+	"\x06events\x18\x01 \x03(\v2\x15.worker.v1.AuditEventR\x06events\"#\n" +
 	"\rGetJobRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\"2\n" +
 	"\x0eGetJobResponse\x12 \n" +
@@ -3871,7 +4105,7 @@ const file_worker_v1_admin_proto_rawDesc = "" +
 	"\x14ReplayDLQByIDRequest\x12\x10\n" +
 	"\x03ids\x18\x01 \x03(\tR\x03ids\"-\n" +
 	"\x15ReplayDLQByIDResponse\x12\x14\n" +
-	"\x05moved\x18\x01 \x01(\x05R\x05moved2\xfe\x10\n" +
+	"\x05moved\x18\x01 \x01(\x05R\x05moved2\xd8\x11\n" +
 	"\fAdminService\x12F\n" +
 	"\tGetHealth\x12\x1b.worker.v1.GetHealthRequest\x1a\x1c.worker.v1.GetHealthResponse\x12L\n" +
 	"\vGetOverview\x12\x1d.worker.v1.GetOverviewRequest\x1a\x1e.worker.v1.GetOverviewResponse\x12I\n" +
@@ -3883,7 +4117,8 @@ const file_worker_v1_admin_proto_rawDesc = "" +
 	"\n" +
 	"PauseQueue\x12\x1c.worker.v1.PauseQueueRequest\x1a\x1d.worker.v1.PauseQueueResponse\x12C\n" +
 	"\bListJobs\x12\x1a.worker.v1.ListJobsRequest\x1a\x1b.worker.v1.ListJobsResponse\x12R\n" +
-	"\rListJobEvents\x12\x1f.worker.v1.ListJobEventsRequest\x1a .worker.v1.ListJobEventsResponse\x12=\n" +
+	"\rListJobEvents\x12\x1f.worker.v1.ListJobEventsRequest\x1a .worker.v1.ListJobEventsResponse\x12X\n" +
+	"\x0fListAuditEvents\x12!.worker.v1.ListAuditEventsRequest\x1a\".worker.v1.ListAuditEventsResponse\x12=\n" +
 	"\x06GetJob\x12\x18.worker.v1.GetJobRequest\x1a\x19.worker.v1.GetJobResponse\x12F\n" +
 	"\tUpsertJob\x12\x1b.worker.v1.UpsertJobRequest\x1a\x1c.worker.v1.UpsertJobResponse\x12F\n" +
 	"\tDeleteJob\x12\x1b.worker.v1.DeleteJobRequest\x1a\x1c.worker.v1.DeleteJobResponse\x12=\n" +
@@ -3918,78 +4153,85 @@ func file_worker_v1_admin_proto_rawDescGZIP() []byte {
 	return file_worker_v1_admin_proto_rawDescData
 }
 
-var file_worker_v1_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 69)
-var file_worker_v1_admin_proto_goTypes = []any{
-	(*GetOverviewRequest)(nil),            // 0: worker.v1.GetOverviewRequest
-	(*OverviewStats)(nil),                 // 1: worker.v1.OverviewStats
-	(*CoordinationStatus)(nil),            // 2: worker.v1.CoordinationStatus
-	(*AdminActionCounters)(nil),           // 3: worker.v1.AdminActionCounters
-	(*GetOverviewResponse)(nil),           // 4: worker.v1.GetOverviewResponse
-	(*GetHealthRequest)(nil),              // 5: worker.v1.GetHealthRequest
-	(*GetHealthResponse)(nil),             // 6: worker.v1.GetHealthResponse
-	(*QueueSummary)(nil),                  // 7: worker.v1.QueueSummary
-	(*ListQueuesRequest)(nil),             // 8: worker.v1.ListQueuesRequest
-	(*ListQueuesResponse)(nil),            // 9: worker.v1.ListQueuesResponse
-	(*GetQueueRequest)(nil),               // 10: worker.v1.GetQueueRequest
-	(*GetQueueResponse)(nil),              // 11: worker.v1.GetQueueResponse
-	(*UpdateQueueWeightRequest)(nil),      // 12: worker.v1.UpdateQueueWeightRequest
-	(*UpdateQueueWeightResponse)(nil),     // 13: worker.v1.UpdateQueueWeightResponse
-	(*ResetQueueWeightRequest)(nil),       // 14: worker.v1.ResetQueueWeightRequest
-	(*ResetQueueWeightResponse)(nil),      // 15: worker.v1.ResetQueueWeightResponse
-	(*PauseQueueRequest)(nil),             // 16: worker.v1.PauseQueueRequest
-	(*PauseQueueResponse)(nil),            // 17: worker.v1.PauseQueueResponse
-	(*ScheduleEntry)(nil),                 // 18: worker.v1.ScheduleEntry
-	(*ScheduleFactory)(nil),               // 19: worker.v1.ScheduleFactory
-	(*ScheduleEvent)(nil),                 // 20: worker.v1.ScheduleEvent
-	(*ListScheduleFactoriesRequest)(nil),  // 21: worker.v1.ListScheduleFactoriesRequest
-	(*ListScheduleFactoriesResponse)(nil), // 22: worker.v1.ListScheduleFactoriesResponse
-	(*ListScheduleEventsRequest)(nil),     // 23: worker.v1.ListScheduleEventsRequest
-	(*ListScheduleEventsResponse)(nil),    // 24: worker.v1.ListScheduleEventsResponse
-	(*ListSchedulesRequest)(nil),          // 25: worker.v1.ListSchedulesRequest
-	(*ListSchedulesResponse)(nil),         // 26: worker.v1.ListSchedulesResponse
-	(*CreateScheduleRequest)(nil),         // 27: worker.v1.CreateScheduleRequest
-	(*CreateScheduleResponse)(nil),        // 28: worker.v1.CreateScheduleResponse
-	(*DeleteScheduleRequest)(nil),         // 29: worker.v1.DeleteScheduleRequest
-	(*DeleteScheduleResponse)(nil),        // 30: worker.v1.DeleteScheduleResponse
-	(*PauseScheduleRequest)(nil),          // 31: worker.v1.PauseScheduleRequest
-	(*PauseScheduleResponse)(nil),         // 32: worker.v1.PauseScheduleResponse
-	(*RunScheduleRequest)(nil),            // 33: worker.v1.RunScheduleRequest
-	(*RunScheduleResponse)(nil),           // 34: worker.v1.RunScheduleResponse
-	(*PauseSchedulesRequest)(nil),         // 35: worker.v1.PauseSchedulesRequest
-	(*PauseSchedulesResponse)(nil),        // 36: worker.v1.PauseSchedulesResponse
-	(*JobSpec)(nil),                       // 37: worker.v1.JobSpec
-	(*Job)(nil),                           // 38: worker.v1.Job
-	(*JobEvent)(nil),                      // 39: worker.v1.JobEvent
-	(*ListJobsRequest)(nil),               // 40: worker.v1.ListJobsRequest
-	(*ListJobsResponse)(nil),              // 41: worker.v1.ListJobsResponse
-	(*ListJobEventsRequest)(nil),          // 42: worker.v1.ListJobEventsRequest
-	(*ListJobEventsResponse)(nil),         // 43: worker.v1.ListJobEventsResponse
-	(*GetJobRequest)(nil),                 // 44: worker.v1.GetJobRequest
-	(*GetJobResponse)(nil),                // 45: worker.v1.GetJobResponse
-	(*UpsertJobRequest)(nil),              // 46: worker.v1.UpsertJobRequest
-	(*UpsertJobResponse)(nil),             // 47: worker.v1.UpsertJobResponse
-	(*DeleteJobRequest)(nil),              // 48: worker.v1.DeleteJobRequest
-	(*DeleteJobResponse)(nil),             // 49: worker.v1.DeleteJobResponse
-	(*RunJobRequest)(nil),                 // 50: worker.v1.RunJobRequest
-	(*RunJobResponse)(nil),                // 51: worker.v1.RunJobResponse
-	(*DLQEntry)(nil),                      // 52: worker.v1.DLQEntry
-	(*DLQEntryDetail)(nil),                // 53: worker.v1.DLQEntryDetail
-	(*GetDLQEntryRequest)(nil),            // 54: worker.v1.GetDLQEntryRequest
-	(*GetDLQEntryResponse)(nil),           // 55: worker.v1.GetDLQEntryResponse
-	(*ListDLQRequest)(nil),                // 56: worker.v1.ListDLQRequest
-	(*ListDLQResponse)(nil),               // 57: worker.v1.ListDLQResponse
-	(*PauseDequeueRequest)(nil),           // 58: worker.v1.PauseDequeueRequest
-	(*PauseDequeueResponse)(nil),          // 59: worker.v1.PauseDequeueResponse
-	(*ResumeDequeueRequest)(nil),          // 60: worker.v1.ResumeDequeueRequest
-	(*ResumeDequeueResponse)(nil),         // 61: worker.v1.ResumeDequeueResponse
-	(*ReplayDLQRequest)(nil),              // 62: worker.v1.ReplayDLQRequest
-	(*ReplayDLQResponse)(nil),             // 63: worker.v1.ReplayDLQResponse
-	(*ReplayDLQByIDRequest)(nil),          // 64: worker.v1.ReplayDLQByIDRequest
-	(*ReplayDLQByIDResponse)(nil),         // 65: worker.v1.ReplayDLQByIDResponse
-	nil,                                   // 66: worker.v1.ScheduleEvent.MetadataEntry
-	nil,                                   // 67: worker.v1.JobEvent.MetadataEntry
-	nil,                                   // 68: worker.v1.DLQEntryDetail.MetadataEntry
-}
+var (
+	file_worker_v1_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 73)
+	file_worker_v1_admin_proto_goTypes  = []any{
+		(*GetOverviewRequest)(nil),            // 0: worker.v1.GetOverviewRequest
+		(*OverviewStats)(nil),                 // 1: worker.v1.OverviewStats
+		(*CoordinationStatus)(nil),            // 2: worker.v1.CoordinationStatus
+		(*AdminActionCounters)(nil),           // 3: worker.v1.AdminActionCounters
+		(*GetOverviewResponse)(nil),           // 4: worker.v1.GetOverviewResponse
+		(*GetHealthRequest)(nil),              // 5: worker.v1.GetHealthRequest
+		(*GetHealthResponse)(nil),             // 6: worker.v1.GetHealthResponse
+		(*QueueSummary)(nil),                  // 7: worker.v1.QueueSummary
+		(*ListQueuesRequest)(nil),             // 8: worker.v1.ListQueuesRequest
+		(*ListQueuesResponse)(nil),            // 9: worker.v1.ListQueuesResponse
+		(*GetQueueRequest)(nil),               // 10: worker.v1.GetQueueRequest
+		(*GetQueueResponse)(nil),              // 11: worker.v1.GetQueueResponse
+		(*UpdateQueueWeightRequest)(nil),      // 12: worker.v1.UpdateQueueWeightRequest
+		(*UpdateQueueWeightResponse)(nil),     // 13: worker.v1.UpdateQueueWeightResponse
+		(*ResetQueueWeightRequest)(nil),       // 14: worker.v1.ResetQueueWeightRequest
+		(*ResetQueueWeightResponse)(nil),      // 15: worker.v1.ResetQueueWeightResponse
+		(*PauseQueueRequest)(nil),             // 16: worker.v1.PauseQueueRequest
+		(*PauseQueueResponse)(nil),            // 17: worker.v1.PauseQueueResponse
+		(*ScheduleEntry)(nil),                 // 18: worker.v1.ScheduleEntry
+		(*ScheduleFactory)(nil),               // 19: worker.v1.ScheduleFactory
+		(*ScheduleEvent)(nil),                 // 20: worker.v1.ScheduleEvent
+		(*ListScheduleFactoriesRequest)(nil),  // 21: worker.v1.ListScheduleFactoriesRequest
+		(*ListScheduleFactoriesResponse)(nil), // 22: worker.v1.ListScheduleFactoriesResponse
+		(*ListScheduleEventsRequest)(nil),     // 23: worker.v1.ListScheduleEventsRequest
+		(*ListScheduleEventsResponse)(nil),    // 24: worker.v1.ListScheduleEventsResponse
+		(*ListSchedulesRequest)(nil),          // 25: worker.v1.ListSchedulesRequest
+		(*ListSchedulesResponse)(nil),         // 26: worker.v1.ListSchedulesResponse
+		(*CreateScheduleRequest)(nil),         // 27: worker.v1.CreateScheduleRequest
+		(*CreateScheduleResponse)(nil),        // 28: worker.v1.CreateScheduleResponse
+		(*DeleteScheduleRequest)(nil),         // 29: worker.v1.DeleteScheduleRequest
+		(*DeleteScheduleResponse)(nil),        // 30: worker.v1.DeleteScheduleResponse
+		(*PauseScheduleRequest)(nil),          // 31: worker.v1.PauseScheduleRequest
+		(*PauseScheduleResponse)(nil),         // 32: worker.v1.PauseScheduleResponse
+		(*RunScheduleRequest)(nil),            // 33: worker.v1.RunScheduleRequest
+		(*RunScheduleResponse)(nil),           // 34: worker.v1.RunScheduleResponse
+		(*PauseSchedulesRequest)(nil),         // 35: worker.v1.PauseSchedulesRequest
+		(*PauseSchedulesResponse)(nil),        // 36: worker.v1.PauseSchedulesResponse
+		(*JobSpec)(nil),                       // 37: worker.v1.JobSpec
+		(*Job)(nil),                           // 38: worker.v1.Job
+		(*JobEvent)(nil),                      // 39: worker.v1.JobEvent
+		(*ListJobsRequest)(nil),               // 40: worker.v1.ListJobsRequest
+		(*ListJobsResponse)(nil),              // 41: worker.v1.ListJobsResponse
+		(*ListJobEventsRequest)(nil),          // 42: worker.v1.ListJobEventsRequest
+		(*ListJobEventsResponse)(nil),         // 43: worker.v1.ListJobEventsResponse
+		(*AuditEvent)(nil),                    // 44: worker.v1.AuditEvent
+		(*ListAuditEventsRequest)(nil),        // 45: worker.v1.ListAuditEventsRequest
+		(*ListAuditEventsResponse)(nil),       // 46: worker.v1.ListAuditEventsResponse
+		(*GetJobRequest)(nil),                 // 47: worker.v1.GetJobRequest
+		(*GetJobResponse)(nil),                // 48: worker.v1.GetJobResponse
+		(*UpsertJobRequest)(nil),              // 49: worker.v1.UpsertJobRequest
+		(*UpsertJobResponse)(nil),             // 50: worker.v1.UpsertJobResponse
+		(*DeleteJobRequest)(nil),              // 51: worker.v1.DeleteJobRequest
+		(*DeleteJobResponse)(nil),             // 52: worker.v1.DeleteJobResponse
+		(*RunJobRequest)(nil),                 // 53: worker.v1.RunJobRequest
+		(*RunJobResponse)(nil),                // 54: worker.v1.RunJobResponse
+		(*DLQEntry)(nil),                      // 55: worker.v1.DLQEntry
+		(*DLQEntryDetail)(nil),                // 56: worker.v1.DLQEntryDetail
+		(*GetDLQEntryRequest)(nil),            // 57: worker.v1.GetDLQEntryRequest
+		(*GetDLQEntryResponse)(nil),           // 58: worker.v1.GetDLQEntryResponse
+		(*ListDLQRequest)(nil),                // 59: worker.v1.ListDLQRequest
+		(*ListDLQResponse)(nil),               // 60: worker.v1.ListDLQResponse
+		(*PauseDequeueRequest)(nil),           // 61: worker.v1.PauseDequeueRequest
+		(*PauseDequeueResponse)(nil),          // 62: worker.v1.PauseDequeueResponse
+		(*ResumeDequeueRequest)(nil),          // 63: worker.v1.ResumeDequeueRequest
+		(*ResumeDequeueResponse)(nil),         // 64: worker.v1.ResumeDequeueResponse
+		(*ReplayDLQRequest)(nil),              // 65: worker.v1.ReplayDLQRequest
+		(*ReplayDLQResponse)(nil),             // 66: worker.v1.ReplayDLQResponse
+		(*ReplayDLQByIDRequest)(nil),          // 67: worker.v1.ReplayDLQByIDRequest
+		(*ReplayDLQByIDResponse)(nil),         // 68: worker.v1.ReplayDLQByIDResponse
+		nil,                                   // 69: worker.v1.ScheduleEvent.MetadataEntry
+		nil,                                   // 70: worker.v1.JobEvent.MetadataEntry
+		nil,                                   // 71: worker.v1.AuditEvent.MetadataEntry
+		nil,                                   // 72: worker.v1.DLQEntryDetail.MetadataEntry
+	}
+)
+
 var file_worker_v1_admin_proto_depIdxs = []int32{
 	1,  // 0: worker.v1.GetOverviewResponse.stats:type_name -> worker.v1.OverviewStats
 	2,  // 1: worker.v1.GetOverviewResponse.coordination:type_name -> worker.v1.CoordinationStatus
@@ -3999,81 +4241,85 @@ var file_worker_v1_admin_proto_depIdxs = []int32{
 	7,  // 5: worker.v1.UpdateQueueWeightResponse.queue:type_name -> worker.v1.QueueSummary
 	7,  // 6: worker.v1.ResetQueueWeightResponse.queue:type_name -> worker.v1.QueueSummary
 	7,  // 7: worker.v1.PauseQueueResponse.queue:type_name -> worker.v1.QueueSummary
-	66, // 8: worker.v1.ScheduleEvent.metadata:type_name -> worker.v1.ScheduleEvent.MetadataEntry
+	69, // 8: worker.v1.ScheduleEvent.metadata:type_name -> worker.v1.ScheduleEvent.MetadataEntry
 	19, // 9: worker.v1.ListScheduleFactoriesResponse.factories:type_name -> worker.v1.ScheduleFactory
 	20, // 10: worker.v1.ListScheduleEventsResponse.events:type_name -> worker.v1.ScheduleEvent
 	18, // 11: worker.v1.ListSchedulesResponse.schedules:type_name -> worker.v1.ScheduleEntry
 	18, // 12: worker.v1.CreateScheduleResponse.schedule:type_name -> worker.v1.ScheduleEntry
 	18, // 13: worker.v1.PauseScheduleResponse.schedule:type_name -> worker.v1.ScheduleEntry
 	37, // 14: worker.v1.Job.spec:type_name -> worker.v1.JobSpec
-	67, // 15: worker.v1.JobEvent.metadata:type_name -> worker.v1.JobEvent.MetadataEntry
+	70, // 15: worker.v1.JobEvent.metadata:type_name -> worker.v1.JobEvent.MetadataEntry
 	38, // 16: worker.v1.ListJobsResponse.jobs:type_name -> worker.v1.Job
 	39, // 17: worker.v1.ListJobEventsResponse.events:type_name -> worker.v1.JobEvent
-	38, // 18: worker.v1.GetJobResponse.job:type_name -> worker.v1.Job
-	37, // 19: worker.v1.UpsertJobRequest.spec:type_name -> worker.v1.JobSpec
-	38, // 20: worker.v1.UpsertJobResponse.job:type_name -> worker.v1.Job
-	68, // 21: worker.v1.DLQEntryDetail.metadata:type_name -> worker.v1.DLQEntryDetail.MetadataEntry
-	53, // 22: worker.v1.GetDLQEntryResponse.entry:type_name -> worker.v1.DLQEntryDetail
-	52, // 23: worker.v1.ListDLQResponse.entries:type_name -> worker.v1.DLQEntry
-	5,  // 24: worker.v1.AdminService.GetHealth:input_type -> worker.v1.GetHealthRequest
-	0,  // 25: worker.v1.AdminService.GetOverview:input_type -> worker.v1.GetOverviewRequest
-	8,  // 26: worker.v1.AdminService.ListQueues:input_type -> worker.v1.ListQueuesRequest
-	10, // 27: worker.v1.AdminService.GetQueue:input_type -> worker.v1.GetQueueRequest
-	12, // 28: worker.v1.AdminService.UpdateQueueWeight:input_type -> worker.v1.UpdateQueueWeightRequest
-	14, // 29: worker.v1.AdminService.ResetQueueWeight:input_type -> worker.v1.ResetQueueWeightRequest
-	16, // 30: worker.v1.AdminService.PauseQueue:input_type -> worker.v1.PauseQueueRequest
-	40, // 31: worker.v1.AdminService.ListJobs:input_type -> worker.v1.ListJobsRequest
-	42, // 32: worker.v1.AdminService.ListJobEvents:input_type -> worker.v1.ListJobEventsRequest
-	44, // 33: worker.v1.AdminService.GetJob:input_type -> worker.v1.GetJobRequest
-	46, // 34: worker.v1.AdminService.UpsertJob:input_type -> worker.v1.UpsertJobRequest
-	48, // 35: worker.v1.AdminService.DeleteJob:input_type -> worker.v1.DeleteJobRequest
-	50, // 36: worker.v1.AdminService.RunJob:input_type -> worker.v1.RunJobRequest
-	21, // 37: worker.v1.AdminService.ListScheduleFactories:input_type -> worker.v1.ListScheduleFactoriesRequest
-	23, // 38: worker.v1.AdminService.ListScheduleEvents:input_type -> worker.v1.ListScheduleEventsRequest
-	25, // 39: worker.v1.AdminService.ListSchedules:input_type -> worker.v1.ListSchedulesRequest
-	27, // 40: worker.v1.AdminService.CreateSchedule:input_type -> worker.v1.CreateScheduleRequest
-	29, // 41: worker.v1.AdminService.DeleteSchedule:input_type -> worker.v1.DeleteScheduleRequest
-	31, // 42: worker.v1.AdminService.PauseSchedule:input_type -> worker.v1.PauseScheduleRequest
-	33, // 43: worker.v1.AdminService.RunSchedule:input_type -> worker.v1.RunScheduleRequest
-	35, // 44: worker.v1.AdminService.PauseSchedules:input_type -> worker.v1.PauseSchedulesRequest
-	56, // 45: worker.v1.AdminService.ListDLQ:input_type -> worker.v1.ListDLQRequest
-	54, // 46: worker.v1.AdminService.GetDLQEntry:input_type -> worker.v1.GetDLQEntryRequest
-	58, // 47: worker.v1.AdminService.PauseDequeue:input_type -> worker.v1.PauseDequeueRequest
-	60, // 48: worker.v1.AdminService.ResumeDequeue:input_type -> worker.v1.ResumeDequeueRequest
-	62, // 49: worker.v1.AdminService.ReplayDLQ:input_type -> worker.v1.ReplayDLQRequest
-	64, // 50: worker.v1.AdminService.ReplayDLQByID:input_type -> worker.v1.ReplayDLQByIDRequest
-	6,  // 51: worker.v1.AdminService.GetHealth:output_type -> worker.v1.GetHealthResponse
-	4,  // 52: worker.v1.AdminService.GetOverview:output_type -> worker.v1.GetOverviewResponse
-	9,  // 53: worker.v1.AdminService.ListQueues:output_type -> worker.v1.ListQueuesResponse
-	11, // 54: worker.v1.AdminService.GetQueue:output_type -> worker.v1.GetQueueResponse
-	13, // 55: worker.v1.AdminService.UpdateQueueWeight:output_type -> worker.v1.UpdateQueueWeightResponse
-	15, // 56: worker.v1.AdminService.ResetQueueWeight:output_type -> worker.v1.ResetQueueWeightResponse
-	17, // 57: worker.v1.AdminService.PauseQueue:output_type -> worker.v1.PauseQueueResponse
-	41, // 58: worker.v1.AdminService.ListJobs:output_type -> worker.v1.ListJobsResponse
-	43, // 59: worker.v1.AdminService.ListJobEvents:output_type -> worker.v1.ListJobEventsResponse
-	45, // 60: worker.v1.AdminService.GetJob:output_type -> worker.v1.GetJobResponse
-	47, // 61: worker.v1.AdminService.UpsertJob:output_type -> worker.v1.UpsertJobResponse
-	49, // 62: worker.v1.AdminService.DeleteJob:output_type -> worker.v1.DeleteJobResponse
-	51, // 63: worker.v1.AdminService.RunJob:output_type -> worker.v1.RunJobResponse
-	22, // 64: worker.v1.AdminService.ListScheduleFactories:output_type -> worker.v1.ListScheduleFactoriesResponse
-	24, // 65: worker.v1.AdminService.ListScheduleEvents:output_type -> worker.v1.ListScheduleEventsResponse
-	26, // 66: worker.v1.AdminService.ListSchedules:output_type -> worker.v1.ListSchedulesResponse
-	28, // 67: worker.v1.AdminService.CreateSchedule:output_type -> worker.v1.CreateScheduleResponse
-	30, // 68: worker.v1.AdminService.DeleteSchedule:output_type -> worker.v1.DeleteScheduleResponse
-	32, // 69: worker.v1.AdminService.PauseSchedule:output_type -> worker.v1.PauseScheduleResponse
-	34, // 70: worker.v1.AdminService.RunSchedule:output_type -> worker.v1.RunScheduleResponse
-	36, // 71: worker.v1.AdminService.PauseSchedules:output_type -> worker.v1.PauseSchedulesResponse
-	57, // 72: worker.v1.AdminService.ListDLQ:output_type -> worker.v1.ListDLQResponse
-	55, // 73: worker.v1.AdminService.GetDLQEntry:output_type -> worker.v1.GetDLQEntryResponse
-	59, // 74: worker.v1.AdminService.PauseDequeue:output_type -> worker.v1.PauseDequeueResponse
-	61, // 75: worker.v1.AdminService.ResumeDequeue:output_type -> worker.v1.ResumeDequeueResponse
-	63, // 76: worker.v1.AdminService.ReplayDLQ:output_type -> worker.v1.ReplayDLQResponse
-	65, // 77: worker.v1.AdminService.ReplayDLQByID:output_type -> worker.v1.ReplayDLQByIDResponse
-	51, // [51:78] is the sub-list for method output_type
-	24, // [24:51] is the sub-list for method input_type
-	24, // [24:24] is the sub-list for extension type_name
-	24, // [24:24] is the sub-list for extension extendee
-	0,  // [0:24] is the sub-list for field type_name
+	71, // 18: worker.v1.AuditEvent.metadata:type_name -> worker.v1.AuditEvent.MetadataEntry
+	44, // 19: worker.v1.ListAuditEventsResponse.events:type_name -> worker.v1.AuditEvent
+	38, // 20: worker.v1.GetJobResponse.job:type_name -> worker.v1.Job
+	37, // 21: worker.v1.UpsertJobRequest.spec:type_name -> worker.v1.JobSpec
+	38, // 22: worker.v1.UpsertJobResponse.job:type_name -> worker.v1.Job
+	72, // 23: worker.v1.DLQEntryDetail.metadata:type_name -> worker.v1.DLQEntryDetail.MetadataEntry
+	56, // 24: worker.v1.GetDLQEntryResponse.entry:type_name -> worker.v1.DLQEntryDetail
+	55, // 25: worker.v1.ListDLQResponse.entries:type_name -> worker.v1.DLQEntry
+	5,  // 26: worker.v1.AdminService.GetHealth:input_type -> worker.v1.GetHealthRequest
+	0,  // 27: worker.v1.AdminService.GetOverview:input_type -> worker.v1.GetOverviewRequest
+	8,  // 28: worker.v1.AdminService.ListQueues:input_type -> worker.v1.ListQueuesRequest
+	10, // 29: worker.v1.AdminService.GetQueue:input_type -> worker.v1.GetQueueRequest
+	12, // 30: worker.v1.AdminService.UpdateQueueWeight:input_type -> worker.v1.UpdateQueueWeightRequest
+	14, // 31: worker.v1.AdminService.ResetQueueWeight:input_type -> worker.v1.ResetQueueWeightRequest
+	16, // 32: worker.v1.AdminService.PauseQueue:input_type -> worker.v1.PauseQueueRequest
+	40, // 33: worker.v1.AdminService.ListJobs:input_type -> worker.v1.ListJobsRequest
+	42, // 34: worker.v1.AdminService.ListJobEvents:input_type -> worker.v1.ListJobEventsRequest
+	45, // 35: worker.v1.AdminService.ListAuditEvents:input_type -> worker.v1.ListAuditEventsRequest
+	47, // 36: worker.v1.AdminService.GetJob:input_type -> worker.v1.GetJobRequest
+	49, // 37: worker.v1.AdminService.UpsertJob:input_type -> worker.v1.UpsertJobRequest
+	51, // 38: worker.v1.AdminService.DeleteJob:input_type -> worker.v1.DeleteJobRequest
+	53, // 39: worker.v1.AdminService.RunJob:input_type -> worker.v1.RunJobRequest
+	21, // 40: worker.v1.AdminService.ListScheduleFactories:input_type -> worker.v1.ListScheduleFactoriesRequest
+	23, // 41: worker.v1.AdminService.ListScheduleEvents:input_type -> worker.v1.ListScheduleEventsRequest
+	25, // 42: worker.v1.AdminService.ListSchedules:input_type -> worker.v1.ListSchedulesRequest
+	27, // 43: worker.v1.AdminService.CreateSchedule:input_type -> worker.v1.CreateScheduleRequest
+	29, // 44: worker.v1.AdminService.DeleteSchedule:input_type -> worker.v1.DeleteScheduleRequest
+	31, // 45: worker.v1.AdminService.PauseSchedule:input_type -> worker.v1.PauseScheduleRequest
+	33, // 46: worker.v1.AdminService.RunSchedule:input_type -> worker.v1.RunScheduleRequest
+	35, // 47: worker.v1.AdminService.PauseSchedules:input_type -> worker.v1.PauseSchedulesRequest
+	59, // 48: worker.v1.AdminService.ListDLQ:input_type -> worker.v1.ListDLQRequest
+	57, // 49: worker.v1.AdminService.GetDLQEntry:input_type -> worker.v1.GetDLQEntryRequest
+	61, // 50: worker.v1.AdminService.PauseDequeue:input_type -> worker.v1.PauseDequeueRequest
+	63, // 51: worker.v1.AdminService.ResumeDequeue:input_type -> worker.v1.ResumeDequeueRequest
+	65, // 52: worker.v1.AdminService.ReplayDLQ:input_type -> worker.v1.ReplayDLQRequest
+	67, // 53: worker.v1.AdminService.ReplayDLQByID:input_type -> worker.v1.ReplayDLQByIDRequest
+	6,  // 54: worker.v1.AdminService.GetHealth:output_type -> worker.v1.GetHealthResponse
+	4,  // 55: worker.v1.AdminService.GetOverview:output_type -> worker.v1.GetOverviewResponse
+	9,  // 56: worker.v1.AdminService.ListQueues:output_type -> worker.v1.ListQueuesResponse
+	11, // 57: worker.v1.AdminService.GetQueue:output_type -> worker.v1.GetQueueResponse
+	13, // 58: worker.v1.AdminService.UpdateQueueWeight:output_type -> worker.v1.UpdateQueueWeightResponse
+	15, // 59: worker.v1.AdminService.ResetQueueWeight:output_type -> worker.v1.ResetQueueWeightResponse
+	17, // 60: worker.v1.AdminService.PauseQueue:output_type -> worker.v1.PauseQueueResponse
+	41, // 61: worker.v1.AdminService.ListJobs:output_type -> worker.v1.ListJobsResponse
+	43, // 62: worker.v1.AdminService.ListJobEvents:output_type -> worker.v1.ListJobEventsResponse
+	46, // 63: worker.v1.AdminService.ListAuditEvents:output_type -> worker.v1.ListAuditEventsResponse
+	48, // 64: worker.v1.AdminService.GetJob:output_type -> worker.v1.GetJobResponse
+	50, // 65: worker.v1.AdminService.UpsertJob:output_type -> worker.v1.UpsertJobResponse
+	52, // 66: worker.v1.AdminService.DeleteJob:output_type -> worker.v1.DeleteJobResponse
+	54, // 67: worker.v1.AdminService.RunJob:output_type -> worker.v1.RunJobResponse
+	22, // 68: worker.v1.AdminService.ListScheduleFactories:output_type -> worker.v1.ListScheduleFactoriesResponse
+	24, // 69: worker.v1.AdminService.ListScheduleEvents:output_type -> worker.v1.ListScheduleEventsResponse
+	26, // 70: worker.v1.AdminService.ListSchedules:output_type -> worker.v1.ListSchedulesResponse
+	28, // 71: worker.v1.AdminService.CreateSchedule:output_type -> worker.v1.CreateScheduleResponse
+	30, // 72: worker.v1.AdminService.DeleteSchedule:output_type -> worker.v1.DeleteScheduleResponse
+	32, // 73: worker.v1.AdminService.PauseSchedule:output_type -> worker.v1.PauseScheduleResponse
+	34, // 74: worker.v1.AdminService.RunSchedule:output_type -> worker.v1.RunScheduleResponse
+	36, // 75: worker.v1.AdminService.PauseSchedules:output_type -> worker.v1.PauseSchedulesResponse
+	60, // 76: worker.v1.AdminService.ListDLQ:output_type -> worker.v1.ListDLQResponse
+	58, // 77: worker.v1.AdminService.GetDLQEntry:output_type -> worker.v1.GetDLQEntryResponse
+	62, // 78: worker.v1.AdminService.PauseDequeue:output_type -> worker.v1.PauseDequeueResponse
+	64, // 79: worker.v1.AdminService.ResumeDequeue:output_type -> worker.v1.ResumeDequeueResponse
+	66, // 80: worker.v1.AdminService.ReplayDLQ:output_type -> worker.v1.ReplayDLQResponse
+	68, // 81: worker.v1.AdminService.ReplayDLQByID:output_type -> worker.v1.ReplayDLQByIDResponse
+	54, // [54:82] is the sub-list for method output_type
+	26, // [26:54] is the sub-list for method input_type
+	26, // [26:26] is the sub-list for extension type_name
+	26, // [26:26] is the sub-list for extension extendee
+	0,  // [0:26] is the sub-list for field type_name
 }
 
 func init() { file_worker_v1_admin_proto_init() }
@@ -4087,7 +4333,7 @@ func file_worker_v1_admin_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_worker_v1_admin_proto_rawDesc), len(file_worker_v1_admin_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   69,
+			NumMessages:   73,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/worker/v1/admin_grpc.pb.go
+++ b/pkg/worker/v1/admin_grpc.pb.go
@@ -8,6 +8,7 @@ package workerpb
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -28,6 +29,7 @@ const (
 	AdminService_PauseQueue_FullMethodName            = "/worker.v1.AdminService/PauseQueue"
 	AdminService_ListJobs_FullMethodName              = "/worker.v1.AdminService/ListJobs"
 	AdminService_ListJobEvents_FullMethodName         = "/worker.v1.AdminService/ListJobEvents"
+	AdminService_ListAuditEvents_FullMethodName       = "/worker.v1.AdminService/ListAuditEvents"
 	AdminService_GetJob_FullMethodName                = "/worker.v1.AdminService/GetJob"
 	AdminService_UpsertJob_FullMethodName             = "/worker.v1.AdminService/UpsertJob"
 	AdminService_DeleteJob_FullMethodName             = "/worker.v1.AdminService/DeleteJob"
@@ -61,6 +63,7 @@ type AdminServiceClient interface {
 	PauseQueue(ctx context.Context, in *PauseQueueRequest, opts ...grpc.CallOption) (*PauseQueueResponse, error)
 	ListJobs(ctx context.Context, in *ListJobsRequest, opts ...grpc.CallOption) (*ListJobsResponse, error)
 	ListJobEvents(ctx context.Context, in *ListJobEventsRequest, opts ...grpc.CallOption) (*ListJobEventsResponse, error)
+	ListAuditEvents(ctx context.Context, in *ListAuditEventsRequest, opts ...grpc.CallOption) (*ListAuditEventsResponse, error)
 	GetJob(ctx context.Context, in *GetJobRequest, opts ...grpc.CallOption) (*GetJobResponse, error)
 	UpsertJob(ctx context.Context, in *UpsertJobRequest, opts ...grpc.CallOption) (*UpsertJobResponse, error)
 	DeleteJob(ctx context.Context, in *DeleteJobRequest, opts ...grpc.CallOption) (*DeleteJobResponse, error)
@@ -173,6 +176,16 @@ func (c *adminServiceClient) ListJobEvents(ctx context.Context, in *ListJobEvent
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ListJobEventsResponse)
 	err := c.cc.Invoke(ctx, AdminService_ListJobEvents_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *adminServiceClient) ListAuditEvents(ctx context.Context, in *ListAuditEventsRequest, opts ...grpc.CallOption) (*ListAuditEventsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListAuditEventsResponse)
+	err := c.cc.Invoke(ctx, AdminService_ListAuditEvents_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -372,6 +385,7 @@ type AdminServiceServer interface {
 	PauseQueue(context.Context, *PauseQueueRequest) (*PauseQueueResponse, error)
 	ListJobs(context.Context, *ListJobsRequest) (*ListJobsResponse, error)
 	ListJobEvents(context.Context, *ListJobEventsRequest) (*ListJobEventsResponse, error)
+	ListAuditEvents(context.Context, *ListAuditEventsRequest) (*ListAuditEventsResponse, error)
 	GetJob(context.Context, *GetJobRequest) (*GetJobResponse, error)
 	UpsertJob(context.Context, *UpsertJobRequest) (*UpsertJobResponse, error)
 	DeleteJob(context.Context, *DeleteJobRequest) (*DeleteJobResponse, error)
@@ -402,81 +416,111 @@ type UnimplementedAdminServiceServer struct{}
 func (UnimplementedAdminServiceServer) GetHealth(context.Context, *GetHealthRequest) (*GetHealthResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetHealth not implemented")
 }
+
 func (UnimplementedAdminServiceServer) GetOverview(context.Context, *GetOverviewRequest) (*GetOverviewResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetOverview not implemented")
 }
+
 func (UnimplementedAdminServiceServer) ListQueues(context.Context, *ListQueuesRequest) (*ListQueuesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListQueues not implemented")
 }
+
 func (UnimplementedAdminServiceServer) GetQueue(context.Context, *GetQueueRequest) (*GetQueueResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetQueue not implemented")
 }
+
 func (UnimplementedAdminServiceServer) UpdateQueueWeight(context.Context, *UpdateQueueWeightRequest) (*UpdateQueueWeightResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method UpdateQueueWeight not implemented")
 }
+
 func (UnimplementedAdminServiceServer) ResetQueueWeight(context.Context, *ResetQueueWeightRequest) (*ResetQueueWeightResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ResetQueueWeight not implemented")
 }
+
 func (UnimplementedAdminServiceServer) PauseQueue(context.Context, *PauseQueueRequest) (*PauseQueueResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method PauseQueue not implemented")
 }
+
 func (UnimplementedAdminServiceServer) ListJobs(context.Context, *ListJobsRequest) (*ListJobsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListJobs not implemented")
 }
+
 func (UnimplementedAdminServiceServer) ListJobEvents(context.Context, *ListJobEventsRequest) (*ListJobEventsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListJobEvents not implemented")
 }
+
+func (UnimplementedAdminServiceServer) ListAuditEvents(context.Context, *ListAuditEventsRequest) (*ListAuditEventsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListAuditEvents not implemented")
+}
+
 func (UnimplementedAdminServiceServer) GetJob(context.Context, *GetJobRequest) (*GetJobResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetJob not implemented")
 }
+
 func (UnimplementedAdminServiceServer) UpsertJob(context.Context, *UpsertJobRequest) (*UpsertJobResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method UpsertJob not implemented")
 }
+
 func (UnimplementedAdminServiceServer) DeleteJob(context.Context, *DeleteJobRequest) (*DeleteJobResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteJob not implemented")
 }
+
 func (UnimplementedAdminServiceServer) RunJob(context.Context, *RunJobRequest) (*RunJobResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RunJob not implemented")
 }
+
 func (UnimplementedAdminServiceServer) ListScheduleFactories(context.Context, *ListScheduleFactoriesRequest) (*ListScheduleFactoriesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListScheduleFactories not implemented")
 }
+
 func (UnimplementedAdminServiceServer) ListScheduleEvents(context.Context, *ListScheduleEventsRequest) (*ListScheduleEventsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListScheduleEvents not implemented")
 }
+
 func (UnimplementedAdminServiceServer) ListSchedules(context.Context, *ListSchedulesRequest) (*ListSchedulesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListSchedules not implemented")
 }
+
 func (UnimplementedAdminServiceServer) CreateSchedule(context.Context, *CreateScheduleRequest) (*CreateScheduleResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CreateSchedule not implemented")
 }
+
 func (UnimplementedAdminServiceServer) DeleteSchedule(context.Context, *DeleteScheduleRequest) (*DeleteScheduleResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteSchedule not implemented")
 }
+
 func (UnimplementedAdminServiceServer) PauseSchedule(context.Context, *PauseScheduleRequest) (*PauseScheduleResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method PauseSchedule not implemented")
 }
+
 func (UnimplementedAdminServiceServer) RunSchedule(context.Context, *RunScheduleRequest) (*RunScheduleResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RunSchedule not implemented")
 }
+
 func (UnimplementedAdminServiceServer) PauseSchedules(context.Context, *PauseSchedulesRequest) (*PauseSchedulesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method PauseSchedules not implemented")
 }
+
 func (UnimplementedAdminServiceServer) ListDLQ(context.Context, *ListDLQRequest) (*ListDLQResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListDLQ not implemented")
 }
+
 func (UnimplementedAdminServiceServer) GetDLQEntry(context.Context, *GetDLQEntryRequest) (*GetDLQEntryResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetDLQEntry not implemented")
 }
+
 func (UnimplementedAdminServiceServer) PauseDequeue(context.Context, *PauseDequeueRequest) (*PauseDequeueResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method PauseDequeue not implemented")
 }
+
 func (UnimplementedAdminServiceServer) ResumeDequeue(context.Context, *ResumeDequeueRequest) (*ResumeDequeueResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ResumeDequeue not implemented")
 }
+
 func (UnimplementedAdminServiceServer) ReplayDLQ(context.Context, *ReplayDLQRequest) (*ReplayDLQResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ReplayDLQ not implemented")
 }
+
 func (UnimplementedAdminServiceServer) ReplayDLQByID(context.Context, *ReplayDLQByIDRequest) (*ReplayDLQByIDResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ReplayDLQByID not implemented")
 }
@@ -658,6 +702,24 @@ func _AdminService_ListJobEvents_Handler(srv interface{}, ctx context.Context, d
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(AdminServiceServer).ListJobEvents(ctx, req.(*ListJobEventsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AdminService_ListAuditEvents_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListAuditEventsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AdminServiceServer).ListAuditEvents(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AdminService_ListAuditEvents_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AdminServiceServer).ListAuditEvents(ctx, req.(*ListAuditEventsRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1028,6 +1090,10 @@ var AdminService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListJobEvents",
 			Handler:    _AdminService_ListJobEvents_Handler,
+		},
+		{
+			MethodName: "ListAuditEvents",
+			Handler:    _AdminService_ListAuditEvents_Handler,
 		},
 		{
 			MethodName: "GetJob",

--- a/pkg/worker/v1/payload.pb.go
+++ b/pkg/worker/v1/payload.pb.go
@@ -7,11 +7,12 @@
 package workerpb
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -106,10 +107,13 @@ func file_worker_v1_payload_proto_rawDescGZIP() []byte {
 	return file_worker_v1_payload_proto_rawDescData
 }
 
-var file_worker_v1_payload_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
-var file_worker_v1_payload_proto_goTypes = []any{
-	(*SendEmailPayload)(nil), // 0: worker.v1.SendEmailPayload
-}
+var (
+	file_worker_v1_payload_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+	file_worker_v1_payload_proto_goTypes  = []any{
+		(*SendEmailPayload)(nil), // 0: worker.v1.SendEmailPayload
+	}
+)
+
 var file_worker_v1_payload_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
 	0, // [0:0] is the sub-list for method input_type

--- a/pkg/worker/v1/worker.pb.go
+++ b/pkg/worker/v1/worker.pb.go
@@ -7,13 +7,14 @@
 package workerpb
 
 import (
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
+
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	anypb "google.golang.org/protobuf/types/known/anypb"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
 )
 
 const (
@@ -800,25 +801,28 @@ func file_worker_v1_worker_proto_rawDescGZIP() []byte {
 	return file_worker_v1_worker_proto_rawDescData
 }
 
-var file_worker_v1_worker_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
-var file_worker_v1_worker_proto_goTypes = []any{
-	(*Task)(nil),                         // 0: worker.v1.Task
-	(*RegisterTasksRequest)(nil),         // 1: worker.v1.RegisterTasksRequest
-	(*RegisterTasksResponse)(nil),        // 2: worker.v1.RegisterTasksResponse
-	(*DurableTask)(nil),                  // 3: worker.v1.DurableTask
-	(*RegisterDurableTasksRequest)(nil),  // 4: worker.v1.RegisterDurableTasksRequest
-	(*RegisterDurableTasksResponse)(nil), // 5: worker.v1.RegisterDurableTasksResponse
-	(*StreamResultsRequest)(nil),         // 6: worker.v1.StreamResultsRequest
-	(*StreamResultsResponse)(nil),        // 7: worker.v1.StreamResultsResponse
-	(*CancelTaskRequest)(nil),            // 8: worker.v1.CancelTaskRequest
-	(*CancelTaskResponse)(nil),           // 9: worker.v1.CancelTaskResponse
-	(*GetTaskRequest)(nil),               // 10: worker.v1.GetTaskRequest
-	(*GetTaskResponse)(nil),              // 11: worker.v1.GetTaskResponse
-	nil,                                  // 12: worker.v1.Task.MetadataEntry
-	nil,                                  // 13: worker.v1.DurableTask.MetadataEntry
-	(*durationpb.Duration)(nil),          // 14: google.protobuf.Duration
-	(*anypb.Any)(nil),                    // 15: google.protobuf.Any
-}
+var (
+	file_worker_v1_worker_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
+	file_worker_v1_worker_proto_goTypes  = []any{
+		(*Task)(nil),                         // 0: worker.v1.Task
+		(*RegisterTasksRequest)(nil),         // 1: worker.v1.RegisterTasksRequest
+		(*RegisterTasksResponse)(nil),        // 2: worker.v1.RegisterTasksResponse
+		(*DurableTask)(nil),                  // 3: worker.v1.DurableTask
+		(*RegisterDurableTasksRequest)(nil),  // 4: worker.v1.RegisterDurableTasksRequest
+		(*RegisterDurableTasksResponse)(nil), // 5: worker.v1.RegisterDurableTasksResponse
+		(*StreamResultsRequest)(nil),         // 6: worker.v1.StreamResultsRequest
+		(*StreamResultsResponse)(nil),        // 7: worker.v1.StreamResultsResponse
+		(*CancelTaskRequest)(nil),            // 8: worker.v1.CancelTaskRequest
+		(*CancelTaskResponse)(nil),           // 9: worker.v1.CancelTaskResponse
+		(*GetTaskRequest)(nil),               // 10: worker.v1.GetTaskRequest
+		(*GetTaskResponse)(nil),              // 11: worker.v1.GetTaskResponse
+		nil,                                  // 12: worker.v1.Task.MetadataEntry
+		nil,                                  // 13: worker.v1.DurableTask.MetadataEntry
+		(*durationpb.Duration)(nil),          // 14: google.protobuf.Duration
+		(*anypb.Any)(nil),                    // 15: google.protobuf.Any
+	}
+)
+
 var file_worker_v1_worker_proto_depIdxs = []int32{
 	14, // 0: worker.v1.Task.retry_delay:type_name -> google.protobuf.Duration
 	15, // 1: worker.v1.Task.payload:type_name -> google.protobuf.Any

--- a/pkg/worker/v1/worker_grpc.pb.go
+++ b/pkg/worker/v1/worker_grpc.pb.go
@@ -8,6 +8,7 @@ package workerpb
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -125,15 +126,19 @@ type UnimplementedWorkerServiceServer struct{}
 func (UnimplementedWorkerServiceServer) RegisterTasks(context.Context, *RegisterTasksRequest) (*RegisterTasksResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RegisterTasks not implemented")
 }
+
 func (UnimplementedWorkerServiceServer) RegisterDurableTasks(context.Context, *RegisterDurableTasksRequest) (*RegisterDurableTasksResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RegisterDurableTasks not implemented")
 }
+
 func (UnimplementedWorkerServiceServer) StreamResults(*StreamResultsRequest, grpc.ServerStreamingServer[StreamResultsResponse]) error {
 	return status.Error(codes.Unimplemented, "method StreamResults not implemented")
 }
+
 func (UnimplementedWorkerServiceServer) CancelTask(context.Context, *CancelTaskRequest) (*CancelTaskResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CancelTask not implemented")
 }
+
 func (UnimplementedWorkerServiceServer) GetTask(context.Context, *GetTaskRequest) (*GetTaskResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetTask not implemented")
 }

--- a/proto/worker/v1/admin.proto
+++ b/proto/worker/v1/admin.proto
@@ -245,6 +245,28 @@ message ListJobEventsResponse {
   repeated JobEvent events = 1;
 }
 
+message AuditEvent {
+  int64 at_ms = 1;
+  string actor = 2;
+  string request_id = 3;
+  string action = 4;
+  string target = 5;
+  string status = 6;
+  string payload_hash = 7;
+  string detail = 8;
+  map<string, string> metadata = 9;
+}
+
+message ListAuditEventsRequest {
+  string action = 1;
+  string target = 2;
+  int32 limit = 3;
+}
+
+message ListAuditEventsResponse {
+  repeated AuditEvent events = 1;
+}
+
 message GetJobRequest {
   string name = 1;
 }
@@ -357,6 +379,7 @@ service AdminService {
   rpc PauseQueue(PauseQueueRequest) returns (PauseQueueResponse);
   rpc ListJobs(ListJobsRequest) returns (ListJobsResponse);
   rpc ListJobEvents(ListJobEventsRequest) returns (ListJobEventsResponse);
+  rpc ListAuditEvents(ListAuditEventsRequest) returns (ListAuditEventsResponse);
   rpc GetJob(GetJobRequest) returns (GetJobResponse);
   rpc UpsertJob(UpsertJobRequest) returns (UpsertJobResponse);
   rpc DeleteJob(DeleteJobRequest) returns (DeleteJobResponse);

--- a/tests/bench_test.go
+++ b/tests/bench_test.go
@@ -19,11 +19,11 @@ const (
 	benchRetryDelay          = time.Second
 	benchMaxRetries          = 0
 	benchRetentionMaxEntries = 128
+	benchBatchLarge          = 100
 )
 
 func benchBatchSizes() []int {
-	//nolint:revive
-	return []int{1, 10, 100}
+	return []int{1, 10, benchBatchLarge}
 }
 
 func BenchmarkTaskManager_RegisterWait(b *testing.B) {

--- a/worker.go
+++ b/worker.go
@@ -111,6 +111,10 @@ type TaskManager struct {
 	jobEventsMu   sync.RWMutex
 	jobEvents     []AdminJobEvent
 	jobEventLimit int
+
+	auditEventsMu   sync.RWMutex
+	auditEvents     []AdminAuditEvent
+	auditEventLimit int
 }
 
 // NewTaskManagerWithDefaults creates a new task manager with default values.
@@ -240,6 +244,7 @@ func newTaskManagerFromConfig(ctx context.Context, cfg taskManagerConfig) *TaskM
 		cronEventLimit:      defaultAdminScheduleEventLimit,
 		cronRuns:            map[uuid.UUID]cronRunInfo{},
 		jobEventLimit:       defaultAdminJobEventLimit,
+		auditEventLimit:     normalizeAdminEventLimit(cfg.auditEventLimit, defaultAdminAuditEventLimit),
 	}
 
 	tm.queueCond = sync.NewCond(&tm.queueMu)


### PR DESCRIPTION
- Add audit event model + persistence and expose list/export via REST + gRPC (ListAuditEvents)
- Add artifact endpoints (/admin/v1/jobs/{name}/artifact + /meta) with tarball store support
- Add admin guardrails (limits/approval) and metrics snapshot endpoint; wire through gateway
- Update admin UI to view/filter/export audit events
- Tweak tooling/docs (golangci max-public-structs, PRD updates) and bench batch size