### PR TITLE
chore(proto): regenerate worker v1 Go protobuf/grpc stubs

### DIFF
--- a/pkg/worker/v1/admin.pb.go
+++ b/pkg/worker/v1/admin.pb.go
@@ -7,12 +7,11 @@
 package workerpb
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -4153,85 +4152,82 @@ func file_worker_v1_admin_proto_rawDescGZIP() []byte {
 	return file_worker_v1_admin_proto_rawDescData
 }
 
-var (
-	file_worker_v1_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 73)
-	file_worker_v1_admin_proto_goTypes  = []any{
-		(*GetOverviewRequest)(nil),            // 0: worker.v1.GetOverviewRequest
-		(*OverviewStats)(nil),                 // 1: worker.v1.OverviewStats
-		(*CoordinationStatus)(nil),            // 2: worker.v1.CoordinationStatus
-		(*AdminActionCounters)(nil),           // 3: worker.v1.AdminActionCounters
-		(*GetOverviewResponse)(nil),           // 4: worker.v1.GetOverviewResponse
-		(*GetHealthRequest)(nil),              // 5: worker.v1.GetHealthRequest
-		(*GetHealthResponse)(nil),             // 6: worker.v1.GetHealthResponse
-		(*QueueSummary)(nil),                  // 7: worker.v1.QueueSummary
-		(*ListQueuesRequest)(nil),             // 8: worker.v1.ListQueuesRequest
-		(*ListQueuesResponse)(nil),            // 9: worker.v1.ListQueuesResponse
-		(*GetQueueRequest)(nil),               // 10: worker.v1.GetQueueRequest
-		(*GetQueueResponse)(nil),              // 11: worker.v1.GetQueueResponse
-		(*UpdateQueueWeightRequest)(nil),      // 12: worker.v1.UpdateQueueWeightRequest
-		(*UpdateQueueWeightResponse)(nil),     // 13: worker.v1.UpdateQueueWeightResponse
-		(*ResetQueueWeightRequest)(nil),       // 14: worker.v1.ResetQueueWeightRequest
-		(*ResetQueueWeightResponse)(nil),      // 15: worker.v1.ResetQueueWeightResponse
-		(*PauseQueueRequest)(nil),             // 16: worker.v1.PauseQueueRequest
-		(*PauseQueueResponse)(nil),            // 17: worker.v1.PauseQueueResponse
-		(*ScheduleEntry)(nil),                 // 18: worker.v1.ScheduleEntry
-		(*ScheduleFactory)(nil),               // 19: worker.v1.ScheduleFactory
-		(*ScheduleEvent)(nil),                 // 20: worker.v1.ScheduleEvent
-		(*ListScheduleFactoriesRequest)(nil),  // 21: worker.v1.ListScheduleFactoriesRequest
-		(*ListScheduleFactoriesResponse)(nil), // 22: worker.v1.ListScheduleFactoriesResponse
-		(*ListScheduleEventsRequest)(nil),     // 23: worker.v1.ListScheduleEventsRequest
-		(*ListScheduleEventsResponse)(nil),    // 24: worker.v1.ListScheduleEventsResponse
-		(*ListSchedulesRequest)(nil),          // 25: worker.v1.ListSchedulesRequest
-		(*ListSchedulesResponse)(nil),         // 26: worker.v1.ListSchedulesResponse
-		(*CreateScheduleRequest)(nil),         // 27: worker.v1.CreateScheduleRequest
-		(*CreateScheduleResponse)(nil),        // 28: worker.v1.CreateScheduleResponse
-		(*DeleteScheduleRequest)(nil),         // 29: worker.v1.DeleteScheduleRequest
-		(*DeleteScheduleResponse)(nil),        // 30: worker.v1.DeleteScheduleResponse
-		(*PauseScheduleRequest)(nil),          // 31: worker.v1.PauseScheduleRequest
-		(*PauseScheduleResponse)(nil),         // 32: worker.v1.PauseScheduleResponse
-		(*RunScheduleRequest)(nil),            // 33: worker.v1.RunScheduleRequest
-		(*RunScheduleResponse)(nil),           // 34: worker.v1.RunScheduleResponse
-		(*PauseSchedulesRequest)(nil),         // 35: worker.v1.PauseSchedulesRequest
-		(*PauseSchedulesResponse)(nil),        // 36: worker.v1.PauseSchedulesResponse
-		(*JobSpec)(nil),                       // 37: worker.v1.JobSpec
-		(*Job)(nil),                           // 38: worker.v1.Job
-		(*JobEvent)(nil),                      // 39: worker.v1.JobEvent
-		(*ListJobsRequest)(nil),               // 40: worker.v1.ListJobsRequest
-		(*ListJobsResponse)(nil),              // 41: worker.v1.ListJobsResponse
-		(*ListJobEventsRequest)(nil),          // 42: worker.v1.ListJobEventsRequest
-		(*ListJobEventsResponse)(nil),         // 43: worker.v1.ListJobEventsResponse
-		(*AuditEvent)(nil),                    // 44: worker.v1.AuditEvent
-		(*ListAuditEventsRequest)(nil),        // 45: worker.v1.ListAuditEventsRequest
-		(*ListAuditEventsResponse)(nil),       // 46: worker.v1.ListAuditEventsResponse
-		(*GetJobRequest)(nil),                 // 47: worker.v1.GetJobRequest
-		(*GetJobResponse)(nil),                // 48: worker.v1.GetJobResponse
-		(*UpsertJobRequest)(nil),              // 49: worker.v1.UpsertJobRequest
-		(*UpsertJobResponse)(nil),             // 50: worker.v1.UpsertJobResponse
-		(*DeleteJobRequest)(nil),              // 51: worker.v1.DeleteJobRequest
-		(*DeleteJobResponse)(nil),             // 52: worker.v1.DeleteJobResponse
-		(*RunJobRequest)(nil),                 // 53: worker.v1.RunJobRequest
-		(*RunJobResponse)(nil),                // 54: worker.v1.RunJobResponse
-		(*DLQEntry)(nil),                      // 55: worker.v1.DLQEntry
-		(*DLQEntryDetail)(nil),                // 56: worker.v1.DLQEntryDetail
-		(*GetDLQEntryRequest)(nil),            // 57: worker.v1.GetDLQEntryRequest
-		(*GetDLQEntryResponse)(nil),           // 58: worker.v1.GetDLQEntryResponse
-		(*ListDLQRequest)(nil),                // 59: worker.v1.ListDLQRequest
-		(*ListDLQResponse)(nil),               // 60: worker.v1.ListDLQResponse
-		(*PauseDequeueRequest)(nil),           // 61: worker.v1.PauseDequeueRequest
-		(*PauseDequeueResponse)(nil),          // 62: worker.v1.PauseDequeueResponse
-		(*ResumeDequeueRequest)(nil),          // 63: worker.v1.ResumeDequeueRequest
-		(*ResumeDequeueResponse)(nil),         // 64: worker.v1.ResumeDequeueResponse
-		(*ReplayDLQRequest)(nil),              // 65: worker.v1.ReplayDLQRequest
-		(*ReplayDLQResponse)(nil),             // 66: worker.v1.ReplayDLQResponse
-		(*ReplayDLQByIDRequest)(nil),          // 67: worker.v1.ReplayDLQByIDRequest
-		(*ReplayDLQByIDResponse)(nil),         // 68: worker.v1.ReplayDLQByIDResponse
-		nil,                                   // 69: worker.v1.ScheduleEvent.MetadataEntry
-		nil,                                   // 70: worker.v1.JobEvent.MetadataEntry
-		nil,                                   // 71: worker.v1.AuditEvent.MetadataEntry
-		nil,                                   // 72: worker.v1.DLQEntryDetail.MetadataEntry
-	}
-)
-
+var file_worker_v1_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 73)
+var file_worker_v1_admin_proto_goTypes = []any{
+	(*GetOverviewRequest)(nil),            // 0: worker.v1.GetOverviewRequest
+	(*OverviewStats)(nil),                 // 1: worker.v1.OverviewStats
+	(*CoordinationStatus)(nil),            // 2: worker.v1.CoordinationStatus
+	(*AdminActionCounters)(nil),           // 3: worker.v1.AdminActionCounters
+	(*GetOverviewResponse)(nil),           // 4: worker.v1.GetOverviewResponse
+	(*GetHealthRequest)(nil),              // 5: worker.v1.GetHealthRequest
+	(*GetHealthResponse)(nil),             // 6: worker.v1.GetHealthResponse
+	(*QueueSummary)(nil),                  // 7: worker.v1.QueueSummary
+	(*ListQueuesRequest)(nil),             // 8: worker.v1.ListQueuesRequest
+	(*ListQueuesResponse)(nil),            // 9: worker.v1.ListQueuesResponse
+	(*GetQueueRequest)(nil),               // 10: worker.v1.GetQueueRequest
+	(*GetQueueResponse)(nil),              // 11: worker.v1.GetQueueResponse
+	(*UpdateQueueWeightRequest)(nil),      // 12: worker.v1.UpdateQueueWeightRequest
+	(*UpdateQueueWeightResponse)(nil),     // 13: worker.v1.UpdateQueueWeightResponse
+	(*ResetQueueWeightRequest)(nil),       // 14: worker.v1.ResetQueueWeightRequest
+	(*ResetQueueWeightResponse)(nil),      // 15: worker.v1.ResetQueueWeightResponse
+	(*PauseQueueRequest)(nil),             // 16: worker.v1.PauseQueueRequest
+	(*PauseQueueResponse)(nil),            // 17: worker.v1.PauseQueueResponse
+	(*ScheduleEntry)(nil),                 // 18: worker.v1.ScheduleEntry
+	(*ScheduleFactory)(nil),               // 19: worker.v1.ScheduleFactory
+	(*ScheduleEvent)(nil),                 // 20: worker.v1.ScheduleEvent
+	(*ListScheduleFactoriesRequest)(nil),  // 21: worker.v1.ListScheduleFactoriesRequest
+	(*ListScheduleFactoriesResponse)(nil), // 22: worker.v1.ListScheduleFactoriesResponse
+	(*ListScheduleEventsRequest)(nil),     // 23: worker.v1.ListScheduleEventsRequest
+	(*ListScheduleEventsResponse)(nil),    // 24: worker.v1.ListScheduleEventsResponse
+	(*ListSchedulesRequest)(nil),          // 25: worker.v1.ListSchedulesRequest
+	(*ListSchedulesResponse)(nil),         // 26: worker.v1.ListSchedulesResponse
+	(*CreateScheduleRequest)(nil),         // 27: worker.v1.CreateScheduleRequest
+	(*CreateScheduleResponse)(nil),        // 28: worker.v1.CreateScheduleResponse
+	(*DeleteScheduleRequest)(nil),         // 29: worker.v1.DeleteScheduleRequest
+	(*DeleteScheduleResponse)(nil),        // 30: worker.v1.DeleteScheduleResponse
+	(*PauseScheduleRequest)(nil),          // 31: worker.v1.PauseScheduleRequest
+	(*PauseScheduleResponse)(nil),         // 32: worker.v1.PauseScheduleResponse
+	(*RunScheduleRequest)(nil),            // 33: worker.v1.RunScheduleRequest
+	(*RunScheduleResponse)(nil),           // 34: worker.v1.RunScheduleResponse
+	(*PauseSchedulesRequest)(nil),         // 35: worker.v1.PauseSchedulesRequest
+	(*PauseSchedulesResponse)(nil),        // 36: worker.v1.PauseSchedulesResponse
+	(*JobSpec)(nil),                       // 37: worker.v1.JobSpec
+	(*Job)(nil),                           // 38: worker.v1.Job
+	(*JobEvent)(nil),                      // 39: worker.v1.JobEvent
+	(*ListJobsRequest)(nil),               // 40: worker.v1.ListJobsRequest
+	(*ListJobsResponse)(nil),              // 41: worker.v1.ListJobsResponse
+	(*ListJobEventsRequest)(nil),          // 42: worker.v1.ListJobEventsRequest
+	(*ListJobEventsResponse)(nil),         // 43: worker.v1.ListJobEventsResponse
+	(*AuditEvent)(nil),                    // 44: worker.v1.AuditEvent
+	(*ListAuditEventsRequest)(nil),        // 45: worker.v1.ListAuditEventsRequest
+	(*ListAuditEventsResponse)(nil),       // 46: worker.v1.ListAuditEventsResponse
+	(*GetJobRequest)(nil),                 // 47: worker.v1.GetJobRequest
+	(*GetJobResponse)(nil),                // 48: worker.v1.GetJobResponse
+	(*UpsertJobRequest)(nil),              // 49: worker.v1.UpsertJobRequest
+	(*UpsertJobResponse)(nil),             // 50: worker.v1.UpsertJobResponse
+	(*DeleteJobRequest)(nil),              // 51: worker.v1.DeleteJobRequest
+	(*DeleteJobResponse)(nil),             // 52: worker.v1.DeleteJobResponse
+	(*RunJobRequest)(nil),                 // 53: worker.v1.RunJobRequest
+	(*RunJobResponse)(nil),                // 54: worker.v1.RunJobResponse
+	(*DLQEntry)(nil),                      // 55: worker.v1.DLQEntry
+	(*DLQEntryDetail)(nil),                // 56: worker.v1.DLQEntryDetail
+	(*GetDLQEntryRequest)(nil),            // 57: worker.v1.GetDLQEntryRequest
+	(*GetDLQEntryResponse)(nil),           // 58: worker.v1.GetDLQEntryResponse
+	(*ListDLQRequest)(nil),                // 59: worker.v1.ListDLQRequest
+	(*ListDLQResponse)(nil),               // 60: worker.v1.ListDLQResponse
+	(*PauseDequeueRequest)(nil),           // 61: worker.v1.PauseDequeueRequest
+	(*PauseDequeueResponse)(nil),          // 62: worker.v1.PauseDequeueResponse
+	(*ResumeDequeueRequest)(nil),          // 63: worker.v1.ResumeDequeueRequest
+	(*ResumeDequeueResponse)(nil),         // 64: worker.v1.ResumeDequeueResponse
+	(*ReplayDLQRequest)(nil),              // 65: worker.v1.ReplayDLQRequest
+	(*ReplayDLQResponse)(nil),             // 66: worker.v1.ReplayDLQResponse
+	(*ReplayDLQByIDRequest)(nil),          // 67: worker.v1.ReplayDLQByIDRequest
+	(*ReplayDLQByIDResponse)(nil),         // 68: worker.v1.ReplayDLQByIDResponse
+	nil,                                   // 69: worker.v1.ScheduleEvent.MetadataEntry
+	nil,                                   // 70: worker.v1.JobEvent.MetadataEntry
+	nil,                                   // 71: worker.v1.AuditEvent.MetadataEntry
+	nil,                                   // 72: worker.v1.DLQEntryDetail.MetadataEntry
+}
 var file_worker_v1_admin_proto_depIdxs = []int32{
 	1,  // 0: worker.v1.GetOverviewResponse.stats:type_name -> worker.v1.OverviewStats
 	2,  // 1: worker.v1.GetOverviewResponse.coordination:type_name -> worker.v1.CoordinationStatus

--- a/pkg/worker/v1/admin_grpc.pb.go
+++ b/pkg/worker/v1/admin_grpc.pb.go
@@ -8,7 +8,6 @@ package workerpb
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -416,111 +415,84 @@ type UnimplementedAdminServiceServer struct{}
 func (UnimplementedAdminServiceServer) GetHealth(context.Context, *GetHealthRequest) (*GetHealthResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetHealth not implemented")
 }
-
 func (UnimplementedAdminServiceServer) GetOverview(context.Context, *GetOverviewRequest) (*GetOverviewResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetOverview not implemented")
 }
-
 func (UnimplementedAdminServiceServer) ListQueues(context.Context, *ListQueuesRequest) (*ListQueuesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListQueues not implemented")
 }
-
 func (UnimplementedAdminServiceServer) GetQueue(context.Context, *GetQueueRequest) (*GetQueueResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetQueue not implemented")
 }
-
 func (UnimplementedAdminServiceServer) UpdateQueueWeight(context.Context, *UpdateQueueWeightRequest) (*UpdateQueueWeightResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method UpdateQueueWeight not implemented")
 }
-
 func (UnimplementedAdminServiceServer) ResetQueueWeight(context.Context, *ResetQueueWeightRequest) (*ResetQueueWeightResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ResetQueueWeight not implemented")
 }
-
 func (UnimplementedAdminServiceServer) PauseQueue(context.Context, *PauseQueueRequest) (*PauseQueueResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method PauseQueue not implemented")
 }
-
 func (UnimplementedAdminServiceServer) ListJobs(context.Context, *ListJobsRequest) (*ListJobsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListJobs not implemented")
 }
-
 func (UnimplementedAdminServiceServer) ListJobEvents(context.Context, *ListJobEventsRequest) (*ListJobEventsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListJobEvents not implemented")
 }
-
 func (UnimplementedAdminServiceServer) ListAuditEvents(context.Context, *ListAuditEventsRequest) (*ListAuditEventsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListAuditEvents not implemented")
 }
-
 func (UnimplementedAdminServiceServer) GetJob(context.Context, *GetJobRequest) (*GetJobResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetJob not implemented")
 }
-
 func (UnimplementedAdminServiceServer) UpsertJob(context.Context, *UpsertJobRequest) (*UpsertJobResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method UpsertJob not implemented")
 }
-
 func (UnimplementedAdminServiceServer) DeleteJob(context.Context, *DeleteJobRequest) (*DeleteJobResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteJob not implemented")
 }
-
 func (UnimplementedAdminServiceServer) RunJob(context.Context, *RunJobRequest) (*RunJobResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RunJob not implemented")
 }
-
 func (UnimplementedAdminServiceServer) ListScheduleFactories(context.Context, *ListScheduleFactoriesRequest) (*ListScheduleFactoriesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListScheduleFactories not implemented")
 }
-
 func (UnimplementedAdminServiceServer) ListScheduleEvents(context.Context, *ListScheduleEventsRequest) (*ListScheduleEventsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListScheduleEvents not implemented")
 }
-
 func (UnimplementedAdminServiceServer) ListSchedules(context.Context, *ListSchedulesRequest) (*ListSchedulesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListSchedules not implemented")
 }
-
 func (UnimplementedAdminServiceServer) CreateSchedule(context.Context, *CreateScheduleRequest) (*CreateScheduleResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CreateSchedule not implemented")
 }
-
 func (UnimplementedAdminServiceServer) DeleteSchedule(context.Context, *DeleteScheduleRequest) (*DeleteScheduleResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteSchedule not implemented")
 }
-
 func (UnimplementedAdminServiceServer) PauseSchedule(context.Context, *PauseScheduleRequest) (*PauseScheduleResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method PauseSchedule not implemented")
 }
-
 func (UnimplementedAdminServiceServer) RunSchedule(context.Context, *RunScheduleRequest) (*RunScheduleResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RunSchedule not implemented")
 }
-
 func (UnimplementedAdminServiceServer) PauseSchedules(context.Context, *PauseSchedulesRequest) (*PauseSchedulesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method PauseSchedules not implemented")
 }
-
 func (UnimplementedAdminServiceServer) ListDLQ(context.Context, *ListDLQRequest) (*ListDLQResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListDLQ not implemented")
 }
-
 func (UnimplementedAdminServiceServer) GetDLQEntry(context.Context, *GetDLQEntryRequest) (*GetDLQEntryResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetDLQEntry not implemented")
 }
-
 func (UnimplementedAdminServiceServer) PauseDequeue(context.Context, *PauseDequeueRequest) (*PauseDequeueResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method PauseDequeue not implemented")
 }
-
 func (UnimplementedAdminServiceServer) ResumeDequeue(context.Context, *ResumeDequeueRequest) (*ResumeDequeueResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ResumeDequeue not implemented")
 }
-
 func (UnimplementedAdminServiceServer) ReplayDLQ(context.Context, *ReplayDLQRequest) (*ReplayDLQResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ReplayDLQ not implemented")
 }
-
 func (UnimplementedAdminServiceServer) ReplayDLQByID(context.Context, *ReplayDLQByIDRequest) (*ReplayDLQByIDResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ReplayDLQByID not implemented")
 }

--- a/pkg/worker/v1/payload.pb.go
+++ b/pkg/worker/v1/payload.pb.go
@@ -7,12 +7,11 @@
 package workerpb
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -107,13 +106,10 @@ func file_worker_v1_payload_proto_rawDescGZIP() []byte {
 	return file_worker_v1_payload_proto_rawDescData
 }
 
-var (
-	file_worker_v1_payload_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
-	file_worker_v1_payload_proto_goTypes  = []any{
-		(*SendEmailPayload)(nil), // 0: worker.v1.SendEmailPayload
-	}
-)
-
+var file_worker_v1_payload_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_worker_v1_payload_proto_goTypes = []any{
+	(*SendEmailPayload)(nil), // 0: worker.v1.SendEmailPayload
+}
 var file_worker_v1_payload_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
 	0, // [0:0] is the sub-list for method input_type

--- a/pkg/worker/v1/worker.pb.go
+++ b/pkg/worker/v1/worker.pb.go
@@ -7,14 +7,13 @@
 package workerpb
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	anypb "google.golang.org/protobuf/types/known/anypb"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -801,28 +800,25 @@ func file_worker_v1_worker_proto_rawDescGZIP() []byte {
 	return file_worker_v1_worker_proto_rawDescData
 }
 
-var (
-	file_worker_v1_worker_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
-	file_worker_v1_worker_proto_goTypes  = []any{
-		(*Task)(nil),                         // 0: worker.v1.Task
-		(*RegisterTasksRequest)(nil),         // 1: worker.v1.RegisterTasksRequest
-		(*RegisterTasksResponse)(nil),        // 2: worker.v1.RegisterTasksResponse
-		(*DurableTask)(nil),                  // 3: worker.v1.DurableTask
-		(*RegisterDurableTasksRequest)(nil),  // 4: worker.v1.RegisterDurableTasksRequest
-		(*RegisterDurableTasksResponse)(nil), // 5: worker.v1.RegisterDurableTasksResponse
-		(*StreamResultsRequest)(nil),         // 6: worker.v1.StreamResultsRequest
-		(*StreamResultsResponse)(nil),        // 7: worker.v1.StreamResultsResponse
-		(*CancelTaskRequest)(nil),            // 8: worker.v1.CancelTaskRequest
-		(*CancelTaskResponse)(nil),           // 9: worker.v1.CancelTaskResponse
-		(*GetTaskRequest)(nil),               // 10: worker.v1.GetTaskRequest
-		(*GetTaskResponse)(nil),              // 11: worker.v1.GetTaskResponse
-		nil,                                  // 12: worker.v1.Task.MetadataEntry
-		nil,                                  // 13: worker.v1.DurableTask.MetadataEntry
-		(*durationpb.Duration)(nil),          // 14: google.protobuf.Duration
-		(*anypb.Any)(nil),                    // 15: google.protobuf.Any
-	}
-)
-
+var file_worker_v1_worker_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
+var file_worker_v1_worker_proto_goTypes = []any{
+	(*Task)(nil),                         // 0: worker.v1.Task
+	(*RegisterTasksRequest)(nil),         // 1: worker.v1.RegisterTasksRequest
+	(*RegisterTasksResponse)(nil),        // 2: worker.v1.RegisterTasksResponse
+	(*DurableTask)(nil),                  // 3: worker.v1.DurableTask
+	(*RegisterDurableTasksRequest)(nil),  // 4: worker.v1.RegisterDurableTasksRequest
+	(*RegisterDurableTasksResponse)(nil), // 5: worker.v1.RegisterDurableTasksResponse
+	(*StreamResultsRequest)(nil),         // 6: worker.v1.StreamResultsRequest
+	(*StreamResultsResponse)(nil),        // 7: worker.v1.StreamResultsResponse
+	(*CancelTaskRequest)(nil),            // 8: worker.v1.CancelTaskRequest
+	(*CancelTaskResponse)(nil),           // 9: worker.v1.CancelTaskResponse
+	(*GetTaskRequest)(nil),               // 10: worker.v1.GetTaskRequest
+	(*GetTaskResponse)(nil),              // 11: worker.v1.GetTaskResponse
+	nil,                                  // 12: worker.v1.Task.MetadataEntry
+	nil,                                  // 13: worker.v1.DurableTask.MetadataEntry
+	(*durationpb.Duration)(nil),          // 14: google.protobuf.Duration
+	(*anypb.Any)(nil),                    // 15: google.protobuf.Any
+}
 var file_worker_v1_worker_proto_depIdxs = []int32{
 	14, // 0: worker.v1.Task.retry_delay:type_name -> google.protobuf.Duration
 	15, // 1: worker.v1.Task.payload:type_name -> google.protobuf.Any

--- a/pkg/worker/v1/worker_grpc.pb.go
+++ b/pkg/worker/v1/worker_grpc.pb.go
@@ -8,7 +8,6 @@ package workerpb
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -126,19 +125,15 @@ type UnimplementedWorkerServiceServer struct{}
 func (UnimplementedWorkerServiceServer) RegisterTasks(context.Context, *RegisterTasksRequest) (*RegisterTasksResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RegisterTasks not implemented")
 }
-
 func (UnimplementedWorkerServiceServer) RegisterDurableTasks(context.Context, *RegisterDurableTasksRequest) (*RegisterDurableTasksResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RegisterDurableTasks not implemented")
 }
-
 func (UnimplementedWorkerServiceServer) StreamResults(*StreamResultsRequest, grpc.ServerStreamingServer[StreamResultsResponse]) error {
 	return status.Error(codes.Unimplemented, "method StreamResults not implemented")
 }
-
 func (UnimplementedWorkerServiceServer) CancelTask(context.Context, *CancelTaskRequest) (*CancelTaskResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CancelTask not implemented")
 }
-
 func (UnimplementedWorkerServiceServer) GetTask(context.Context, *GetTaskRequest) (*GetTaskResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetTask not implemented")
 }


### PR DESCRIPTION
Updates generated *.pb.go / *_grpc.pb.go for admin/payload/worker:
- align imports (protoreflect/protoimpl) and ordering
- minor formatting/whitespace cleanups in grpc server stubs No intended functional changes.